### PR TITLE
Add sequence in args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,9 @@ dependencies = [
  "fvm_shared",
  "hex",
  "ipc-api",
+ "rand",
+ "serde_json",
+ "tendermint-rpc",
  "tokio",
 ]
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -12,7 +12,7 @@ use adm_provider::{
 };
 use adm_sdk::{
     network::{use_testnet_addresses, Network as SdkNetwork},
-    TxArgs,
+    TxParams,
 };
 use adm_signer::SubnetID;
 
@@ -97,7 +97,7 @@ impl BroadcastMode {
 }
 
 #[derive(Clone, Debug, Args)]
-struct GasArgs {
+struct TxArgs {
     /// Gas limit for the transaction.
     #[arg(long, env)]
     gas_limit: Option<u64>,
@@ -109,12 +109,16 @@ struct GasArgs {
     /// 1FIL = 10**18 attoFIL.
     #[arg(long, env, value_parser = parse_token_amount_from_atto)]
     gas_premium: Option<TokenAmount>,
+    /// Sequence for the transaction.
+    #[arg(long)]
+    sequence: Option<u64>,
 }
 
-impl GasArgs {
-    /// Returns transaction arguments from the gas arguments.
-    pub fn new_tx_args(&self) -> TxArgs {
-        TxArgs {
+impl TxArgs {
+    /// Creates transaction params from tx related CLI arguments.
+    pub fn to_tx_params(&self) -> TxParams {
+        TxParams {
+            sequence: self.sequence,
             gas_params: GasParams {
                 gas_limit: self.gas_limit.unwrap_or(fvm_shared::BLOCK_GAS_LIMIT),
                 gas_fee_cap: self.gas_fee_cap.clone().unwrap_or_default(),

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -10,10 +10,9 @@ pub mod network;
 
 /// Arguments common to transactions.
 #[derive(Clone, Default, Debug)]
-pub struct TxArgs {
-    // TODO: Add sequence in CLI flags
+pub struct TxParams {
     /// Sender account sequence (nonce).
-    // pub sequence: Option<u64>,
+    pub sequence: Option<u64>,
 
     /// Gas params.
     pub gas_params: GasParams,

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -23,7 +23,12 @@ fvm_shared = { workspace = true }
 fendermint_crypto = { workspace = true }
 fendermint_vm_actor_interface = { workspace = true }
 fendermint_vm_message = { workspace = true }
+tendermint-rpc = { workspace = true }
 
 ipc-api = { workspace = true }
 
 adm_provider = { path = "../provider" }
+
+[dev-dependencies]
+rand = { workspace = true }
+serde_json = { workspace = true }


### PR DESCRIPTION
- Adds support for sequence numbers in CLI arguments.
- Refactors the `set_sequence` and `init_sequence` methods in the `Wallet`. Enhanced the `set_sequence` method to initialize sequence numbers from on-chain state if not provided by using the `init_sequence`. 
-  Refactors some other existing functions.

