### PR TITLE
Remove merkle-tree-rs patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3155,8 +3155,10 @@ dependencies = [
  "num_enum",
  "serde",
  "serde_tuple",
+ "serde_with",
  "strum",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -3519,7 +3521,6 @@ dependencies = [
 [[package]]
 name = "merkle-tree-rs"
 version = "0.1.0"
-source = "git+https://github.com/consensus-shipyard/merkle-tree-rs.git?branch=dev#069f1dcb7f29d389c92cac54b1e687d81c4fd639"
 dependencies = [
  "anyhow",
  "ethers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,9 +78,6 @@ fendermint_vm_message = { git = "ssh://git@github.com/amazingdatamachine/ipc.git
 ipc_actors_abis = { git = "ssh://git@github.com/amazingdatamachine/ipc.git" }
 ipc-api = { git = "ssh://git@github.com/amazingdatamachine/ipc.git" }
 
-[patch.crates-io]
-# Contains some API changes that the upstream has not merged.
-merkle-tree-rs = { git = "https://github.com/consensus-shipyard/merkle-tree-rs.git", branch = "dev" }
 
 # Uncomment entries below when working locally on ipc and this repo simultaneously.
 # Assumes the ipc checkout is in a sibling directory with the same name.


### PR DESCRIPTION
Removes the dependency `patch` for `merkle-tree-rs` in `cargo.toml`.