### PR TITLE
Add wallet service for registering new accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,6 @@ dependencies = [
  "adm_signer",
  "anyhow",
  "clap",
- "dotenv",
  "ethers",
  "fendermint_crypto",
  "fvm_shared",
@@ -1354,12 +1353,6 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
-
-[[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dunce"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ clap = { version = "4.1.14", features = [
 ] }
 clap-stdin = { version = "0.4.0", features = ["tokio"] }
 console = "0.15.8"
-dotenv = "0.15.0"
 ethers = "2.0.14"
 ethers-contract = "2.0.14"
 fnv = "1.0"

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-dotenv = { workspace = true }
 ethers = { workspace = true }
 fvm_shared = { workspace = true }
 log = { workspace = true }

--- a/faucet/env.example
+++ b/faucet/env.example
@@ -1,2 +1,2 @@
-export FAUCET_PRIVATE_KEY=[hex_encoded_private_key]
-export FAUCET_PORT=8081
+export PRIVATE_KEY=[hex_encoded_private_key]
+export LISTEN=localhost:8081

--- a/faucet/src/server.rs
+++ b/faucet/src/server.rs
@@ -1,17 +1,18 @@
+use log::info;
 use warp::Filter;
 
 use crate::Cli;
 
 use util::log_request_details;
 
-pub mod register;
-pub mod shared;
-pub mod util;
+mod register;
+mod shared;
+mod util;
 
 /// Server entrypoint for the faucet service.
 pub async fn run(cli: Cli) -> anyhow::Result<()> {
-    let faucet_pk = cli.faucet_private_key;
-    let port = cli.faucet_port.unwrap_or_default();
+    let faucet_pk = cli.private_key;
+    let listen_addr = cli.listen;
 
     let register_route = register::register_route(faucet_pk.clone());
 
@@ -27,6 +28,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
         .with(log_request_details)
         .recover(shared::handle_rejection);
 
-    warp::serve(router).run(([127, 0, 0, 1], port)).await;
+    info!("Starting server at {}", listen_addr);
+    warp::serve(router).run(listen_addr).await;
     Ok(())
 }

--- a/faucet/src/server/register.rs
+++ b/faucet/src/server/register.rs
@@ -60,7 +60,7 @@ pub async fn handle_register(
         .await
         .map_err(|e| {
             Rejection::from(BadRequest {
-                message: format!("register error: {}", e.to_string()),
+                message: format!("register error: {}", e),
             })
         })?;
     let json = json!(res);

--- a/faucet/src/server/shared.rs
+++ b/faucet/src/server/shared.rs
@@ -58,8 +58,13 @@ pub async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> 
             StatusCode::BAD_REQUEST,
             format!("Invalid Request Body: {}", e),
         )
-    } else if let Some(_) = err.find::<warp::reject::InvalidHeader>() {
+    } else if err.find::<warp::reject::InvalidHeader>().is_some() {
         (StatusCode::BAD_REQUEST, "Invalid Header Value".to_string())
+    } else if err.find::<warp::reject::MethodNotAllowed>().is_some() {
+        (
+            StatusCode::METHOD_NOT_ALLOWED,
+            "Method Not Allowed".to_string(),
+        )
     } else {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -77,7 +82,7 @@ pub async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> 
 /// Filter to pass the private key to the request handler.
 pub fn with_private_key(
     private_key: SecretKey,
-) -> impl Filter<Extract = (SecretKey,), Error = std::convert::Infallible> + Clone {
+) -> impl Filter<Extract = (SecretKey,), Error = Infallible> + Clone {
     warp::any().map(move || private_key.clone())
 }
 

--- a/faucet/src/server/util.rs
+++ b/faucet/src/server/util.rs
@@ -1,4 +1,5 @@
 use log::{error, info, Level};
+use serde_json::json;
 use warp::log::Info;
 
 /// Helper function to log details for each request at specific verbosity levels
@@ -13,17 +14,16 @@ pub fn log_request_details(request: Info) {
         .remote_addr()
         .unwrap_or_else(|| ([0, 0, 0, 0], 0).into());
     let duration = request.elapsed().as_millis();
-    let err = format!(
-        "{} {} {} - {} - {}ms",
-        request.method().as_str(),
-        request.path(),
-        request.status(),
-        addr,
-        duration
-    );
+    let log_data = json!({
+        "method": request.method().as_str(),
+        "path": request.path(),
+        "status": request.status().as_u16(),
+        "client_addr": addr,
+        "duration_ms": duration
+    });
     match level {
-        Level::Error => error!("{}", err),
-        Level::Info => info!("{}", err),
+        Level::Error => error!("{}", log_data),
+        Level::Info => info!("{}", log_data),
         // Only Error & Info are used (Trace, Debug, Warn also possible)
         _ => {}
     }
@@ -32,5 +32,9 @@ pub fn log_request_details(request: Info) {
 /// Helper function to log the incoming request body for a route when
 /// [`Level::Info`] logging is enabled.
 pub fn log_request_body(route: &str, body: &str) {
-    info!("incoming /{} request: {}", route, body);
+    let log_data = json!({
+        "route": route,
+        "body": body
+    });
+    info!("{}", log_data);
 }

--- a/sdk/src/network.rs
+++ b/sdk/src/network.rs
@@ -103,7 +103,7 @@ impl Network {
         })
     }
 
-    /// Returns the network [`Url`] of the CometBFT PRC API.
+    /// Returns the network [`Url`] of the CometBFT RPC API.
     pub fn rpc_url(&self) -> anyhow::Result<Url> {
         match self {
             Network::Mainnet => Err(anyhow!("network is pre-mainnet")),
@@ -121,7 +121,7 @@ impl Network {
         }
     }
 
-    /// Returns the network [`reqwest::Url`] of the EVM PRC API.
+    /// Returns the network [`reqwest::Url`] of the EVM RPC API.
     pub fn evm_rpc_url(&self) -> anyhow::Result<reqwest::Url> {
         match self {
             Network::Mainnet => Err(anyhow!("network is pre-mainnet")),
@@ -160,7 +160,7 @@ impl Network {
         })
     }
 
-    /// Returns the network [`reqwest::Url`] of the parent EVM PRC API.
+    /// Returns the network [`reqwest::Url`] of the parent EVM RPC API.
     pub fn parent_evm_rpc_url(&self) -> anyhow::Result<reqwest::Url> {
         match self {
             Network::Mainnet => Err(anyhow!("network is pre-mainnet")),
@@ -183,6 +183,15 @@ impl Network {
         match self {
             Network::Mainnet => Err(anyhow!("network is pre-mainnet")),
             Network::Testnet => Ok(parse_address(TESTNET_PARENT_EVM_REGISTRY_ADDRESS)?),
+            Network::Localnet | Network::Devnet => Err(anyhow!("network has no parent")),
+        }
+    }
+
+    /// Returns the network [`reqwest::Url`] of the Faucet API.
+    pub fn faucet_api_url(&self) -> anyhow::Result<reqwest::Url> {
+        match self {
+            Network::Mainnet => Err(anyhow!("network is pre-mainnet")),
+            Network::Testnet => Ok(reqwest::Url::from_str(TESTNET_FAUCET_API_URL)?),
             Network::Localnet | Network::Devnet => Err(anyhow!("network has no parent")),
         }
     }


### PR DESCRIPTION
## Summary

Adds an `adm_wallet_service` binary that runs a server to `/register` new accounts, transferring 0 FIL in the process, which is used in a new `adm account register` command.

## Details

- Adds a new `adm account register {--address OR --private-key}` command. Thus, an existing EVM account can "register" themselves on the subnet for free and w/o funds. 
- Uses the SDK to transfer 0 FIL within the subnet, which creates a new account faster than if done on rootnet. This also checks if the address has a sequence on the subnet—thus, ensuring that the tx is _only_ sent to accounts that don't exist.
- Adds `FromStr`, `Display`, and `Deserialize` traits to the `Network` enum, which was needed for getting string values to work with the API.
- Allows for custom wallet service URL, in case someone wants to do this themselves for some reason. Also, only the `testnet` is supported; all other networks will log a failure message.

## How it was tested

Created (many) new accounts on the subnet. To test this out:
- Run the wallet service: `cargo run --bin adm_wallet_service`
- Run the `register` command, like: `adm account register --address 0x48b8c4fbd15f467ade77691483e15ed19f2c804f`. This will either log the tx, or log `account already registered` if it exists (like with this example address). `t4`s are also supported.

See also the help for more info:
```
> adm account register -h
Register a new account on a subnet

Usage: adm account register [OPTIONS]

Options:
  -p, --private-key <PRIVATE_KEY>
          Wallet private key (ECDSA, secp256k1) for signing transactions [env: PRIVATE_KEY=54543813b82100a2c8f6b0d53c72db465caf0d29a30afda01e28c2cb550dccc1]
  -a, --address <ADDRESS>
          Account address. The signer address is used if no address is given
      --wallet-service-url <WALLET_SERVICE_URL>
          Wallet registration URL. This sends a subnet transaction from a sponsoring wallet to new accounts, covering gas fees [env: WALLET_SERVICE_URL=]
      --evm-rpc-url <EVM_RPC_URL>
          The Ethereum API rpc http endpoint
      --evm-rpc-timeout <EVM_RPC_TIMEOUT>
          Timeout for calls to the Ethereum API [default: 60s]
      --evm-rpc-auth-token <EVM_RPC_AUTH_TOKEN>
          Bearer token for any Authorization header
      --evm-gateway <EVM_GATEWAY>
          The gateway contract address
      --evm-registry <EVM_REGISTRY>
          The registry contract address
```

Closes #37 