### PR TITLE
sdk(examples): add getting, deleting obj

### DIFF
--- a/sdk/examples/objectstore_add.rs
+++ b/sdk/examples/objectstore_add.rs
@@ -6,11 +6,11 @@ use std::env;
 use anyhow::anyhow;
 use fendermint_actor_machine::WriteAccess;
 use rand::{thread_rng, Rng};
-use tokio::io::{AsyncSeekExt, AsyncWriteExt};
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::time::{sleep, Duration};
 
 use adm_provider::json_rpc::JsonRpcProvider;
-use adm_sdk::machine::objectstore::QueryOptions;
+use adm_sdk::machine::objectstore::{AddOptions, GetOptions, QueryOptions};
 use adm_sdk::{
     machine::{objectstore::ObjectStore, Machine},
     network::Network,
@@ -59,8 +59,15 @@ async fn main() -> anyhow::Result<()> {
 
     // Add a file to the object store
     let key = "foo/my_file";
+    let mut metadata = std::collections::HashMap::new();
+    metadata.insert("foo".to_string(), "bar".to_string());
+    let options = AddOptions {
+        overwrite: true,
+        metadata,
+        ..Default::default()
+    };
     let tx = machine
-        .add(&provider, &mut signer, key, file, Default::default())
+        .add(&provider, &mut signer, key, file, options)
         .await?;
     println!(
         "Added 1MiB file to object store {} with key {}",
@@ -87,6 +94,30 @@ async fn main() -> anyhow::Result<()> {
             cid, key, object.resolved
         );
     }
+
+    // Download the actual object at `foo/my_file`
+    let obj_file = async_tempfile::TempFile::new().await?;
+    let obj_path = obj_file.file_path().to_owned();
+    println!("Downloading object to {}", obj_path.display());
+    let options = GetOptions {
+        range: Some("0-99".to_string()), // Get the first 100 bytes
+        ..Default::default()
+    };
+    {
+        let open_file = obj_file.open_rw().await?;
+        machine.get(&provider, &key, open_file, options).await?;
+    }
+    // Read the first 10 bytes of your downloaded 100 bytes
+    let mut read_file = tokio::fs::File::open(&obj_path).await?;
+    let mut contents = vec![0; 10];
+    read_file.read(&mut contents).await?;
+    println!("Successfully read first 10 bytes of {}", obj_path.display());
+
+    // Now, delete the object
+    let tx = machine
+        .delete(&provider, &mut signer, &key, Default::default())
+        .await?;
+    println!("Deleted object with key {} at tx 0x{}", key, tx.hash);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Adds examples on how to get and delete an object to the existing object store example. This also includes how to set metadata when adding an object.

## Details

See `sdk/examples/objectstore_add.rs`