### PR TITLE
chore: amd -> hoku

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,155 +42,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "adm_cli"
-version = "0.1.0"
-dependencies = [
- "adm_provider",
- "adm_sdk",
- "adm_signer",
- "anyhow",
- "bytes",
- "cid",
- "clap",
- "clap-stdin",
- "ethers",
- "fendermint_actor_accumulator",
- "fendermint_actor_machine",
- "fendermint_actor_objectstore",
- "fendermint_crypto",
- "fendermint_vm_actor_interface",
- "fendermint_vm_message",
- "fvm_ipld_encoding",
- "fvm_shared",
- "hex",
- "humantime",
- "iroh",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "stderrlog",
- "tendermint-rpc",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "adm_faucet"
-version = "0.1.0"
-dependencies = [
- "adm_provider",
- "adm_sdk",
- "adm_signer",
- "anyhow",
- "clap",
- "ethers",
- "fendermint_crypto",
- "fvm_shared",
- "ipc-api",
- "log",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "stderrlog",
- "tokio",
- "warp",
-]
-
-[[package]]
-name = "adm_provider"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "cid",
- "ethers",
- "fendermint_vm_actor_interface",
- "fendermint_vm_message",
- "futures-util",
- "fvm_ipld_encoding",
- "fvm_shared",
- "ipc-api",
- "iroh",
- "num-traits",
- "prost",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "tendermint",
- "tendermint-proto",
- "tendermint-rpc",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "adm_sdk"
-version = "0.1.0"
-dependencies = [
- "adm_provider",
- "adm_signer",
- "anyhow",
- "async-stream",
- "async-tempfile",
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "cid",
- "console",
- "ethers",
- "ethers-contract",
- "fendermint_actor_accumulator",
- "fendermint_actor_machine",
- "fendermint_actor_objectstore",
- "fendermint_crypto",
- "fendermint_vm_actor_interface",
- "fendermint_vm_message",
- "futures-core",
- "fvm_ipld_encoding",
- "fvm_shared",
- "hex",
- "indicatif",
- "ipc-api",
- "ipc_actors_abis",
- "iroh",
- "lazy_static",
- "num-traits",
- "rand",
- "reqwest 0.11.27",
- "serde",
- "tendermint",
- "tendermint-rpc",
- "tokio",
- "tokio-stream",
- "tokio-util",
-]
-
-[[package]]
-name = "adm_signer"
-version = "0.1.0"
-dependencies = [
- "adm_provider",
- "anyhow",
- "async-trait",
- "fendermint_crypto",
- "fendermint_vm_actor_interface",
- "fendermint_vm_message",
- "fnv",
- "fvm_ipld_encoding",
- "fvm_shared",
- "hex",
- "ipc-api",
- "rand",
- "serde_json",
- "tendermint-rpc",
- "tokio",
-]
-
-[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2402,6 +2253,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_accumulator"
 version = "0.1.0"
+source = "git+ssh://git@github.com/hokunet/ipc.git#02b33d697d921d887267381c63e987a6ed4f7612"
 dependencies = [
  "anyhow",
  "cid",
@@ -2420,6 +2272,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_eam"
 version = "0.1.0"
+source = "git+ssh://git@github.com/hokunet/ipc.git#02b33d697d921d887267381c63e987a6ed4f7612"
 dependencies = [
  "anyhow",
  "cid",
@@ -2440,6 +2293,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_machine"
 version = "0.1.0"
+source = "git+ssh://git@github.com/hokunet/ipc.git#02b33d697d921d887267381c63e987a6ed4f7612"
 dependencies = [
  "anyhow",
  "fil_actor_adm",
@@ -2454,6 +2308,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_objectstore"
 version = "0.1.0"
+source = "git+ssh://git@github.com/hokunet/ipc.git#02b33d697d921d887267381c63e987a6ed4f7612"
 dependencies = [
  "anyhow",
  "cid",
@@ -2472,6 +2327,7 @@ dependencies = [
 [[package]]
 name = "fendermint_crypto"
 version = "0.1.0"
+source = "git+ssh://git@github.com/hokunet/ipc.git#02b33d697d921d887267381c63e987a6ed4f7612"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2483,6 +2339,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_actor_interface"
 version = "0.1.0"
+source = "git+ssh://git@github.com/hokunet/ipc.git#02b33d697d921d887267381c63e987a6ed4f7612"
 dependencies = [
  "anyhow",
  "cid",
@@ -2510,6 +2367,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_core"
 version = "0.1.0"
+source = "git+ssh://git@github.com/hokunet/ipc.git#02b33d697d921d887267381c63e987a6ed4f7612"
 dependencies = [
  "cid",
  "fnv",
@@ -2523,6 +2381,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_encoding"
 version = "0.1.0"
+source = "git+ssh://git@github.com/hokunet/ipc.git#02b33d697d921d887267381c63e987a6ed4f7612"
 dependencies = [
  "cid",
  "fvm_shared",
@@ -2535,6 +2394,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_genesis"
 version = "0.1.0"
+source = "git+ssh://git@github.com/hokunet/ipc.git#02b33d697d921d887267381c63e987a6ed4f7612"
 dependencies = [
  "anyhow",
  "fendermint_actor_eam",
@@ -2552,6 +2412,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_message"
 version = "0.1.0"
+source = "git+ssh://git@github.com/hokunet/ipc.git#02b33d697d921d887267381c63e987a6ed4f7612"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -2592,6 +2453,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 [[package]]
 name = "fil_actor_adm"
 version = "12.0.0"
+source = "git+ssh://git@github.com/hokunet/ipc.git#02b33d697d921d887267381c63e987a6ed4f7612"
 dependencies = [
  "anyhow",
  "cid",
@@ -2611,6 +2473,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_eam"
 version = "12.0.0"
+source = "git+ssh://git@github.com/hokunet/ipc.git#02b33d697d921d887267381c63e987a6ed4f7612"
 dependencies = [
  "anyhow",
  "cid",
@@ -2631,6 +2494,7 @@ dependencies = [
 [[package]]
 name = "fil_actors_evm_shared"
 version = "12.0.0"
+source = "git+ssh://git@github.com/hokunet/ipc.git#02b33d697d921d887267381c63e987a6ed4f7612"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding",
@@ -2643,6 +2507,7 @@ dependencies = [
 [[package]]
 name = "fil_actors_runtime"
 version = "12.0.0"
+source = "git+ssh://git@github.com/hokunet/ipc.git#02b33d697d921d887267381c63e987a6ed4f7612"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -3552,6 +3417,155 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3688e69b38018fec1557254f64c8dc2cc8ec502890182f395dbb0aa997aa5735"
 
 [[package]]
+name = "hoku_cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "cid",
+ "clap",
+ "clap-stdin",
+ "ethers",
+ "fendermint_actor_accumulator",
+ "fendermint_actor_machine",
+ "fendermint_actor_objectstore",
+ "fendermint_crypto",
+ "fendermint_vm_actor_interface",
+ "fendermint_vm_message",
+ "fvm_ipld_encoding",
+ "fvm_shared",
+ "hex",
+ "hoku_provider",
+ "hoku_sdk",
+ "hoku_signer",
+ "humantime",
+ "iroh",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "stderrlog",
+ "tendermint-rpc",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hoku_faucet"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ethers",
+ "fendermint_crypto",
+ "fvm_shared",
+ "hoku_provider",
+ "hoku_sdk",
+ "hoku_signer",
+ "ipc-api",
+ "log",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "stderrlog",
+ "tokio",
+ "warp",
+]
+
+[[package]]
+name = "hoku_provider"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "cid",
+ "ethers",
+ "fendermint_vm_actor_interface",
+ "fendermint_vm_message",
+ "futures-util",
+ "fvm_ipld_encoding",
+ "fvm_shared",
+ "ipc-api",
+ "iroh",
+ "num-traits",
+ "prost",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "tendermint",
+ "tendermint-proto",
+ "tendermint-rpc",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "hoku_sdk"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-tempfile",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "cid",
+ "console",
+ "ethers",
+ "ethers-contract",
+ "fendermint_actor_accumulator",
+ "fendermint_actor_machine",
+ "fendermint_actor_objectstore",
+ "fendermint_crypto",
+ "fendermint_vm_actor_interface",
+ "fendermint_vm_message",
+ "futures-core",
+ "fvm_ipld_encoding",
+ "fvm_shared",
+ "hex",
+ "hoku_provider",
+ "hoku_signer",
+ "indicatif",
+ "ipc-api",
+ "ipc_actors_abis",
+ "iroh",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "reqwest 0.11.27",
+ "serde",
+ "tendermint",
+ "tendermint-rpc",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+]
+
+[[package]]
+name = "hoku_signer"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "fendermint_crypto",
+ "fendermint_vm_actor_interface",
+ "fendermint_vm_message",
+ "fnv",
+ "fvm_ipld_encoding",
+ "fvm_shared",
+ "hex",
+ "hoku_provider",
+ "ipc-api",
+ "rand",
+ "serde_json",
+ "tendermint-rpc",
+ "tokio",
+]
+
+[[package]]
 name = "home"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3989,6 +4003,7 @@ dependencies = [
 [[package]]
 name = "ipc-api"
 version = "0.1.0"
+source = "git+ssh://git@github.com/hokunet/ipc.git#02b33d697d921d887267381c63e987a6ed4f7612"
 dependencies = [
  "anyhow",
  "cid",
@@ -4016,6 +4031,7 @@ dependencies = [
 [[package]]
 name = "ipc-types"
 version = "0.1.0"
+source = "git+ssh://git@github.com/hokunet/ipc.git#02b33d697d921d887267381c63e987a6ed4f7612"
 dependencies = [
  "anyhow",
  "cid",
@@ -4039,6 +4055,7 @@ dependencies = [
 [[package]]
 name = "ipc_actors_abis"
 version = "0.1.0"
+source = "git+ssh://git@github.com/hokunet/ipc.git#02b33d697d921d887267381c63e987a6ed4f7612"
 dependencies = [
  "anyhow",
  "ethers",
@@ -4770,6 +4787,7 @@ dependencies = [
 [[package]]
 name = "merkle-tree-rs"
 version = "0.1.0"
+source = "git+ssh://git@github.com/hokunet/ipc.git#02b33d697d921d887267381c63e987a6ed4f7612"
 dependencies = [
  "anyhow",
  "ethers",
@@ -8693,6 +8711,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vm_api"
 version = "1.0.0"
+source = "git+ssh://git@github.com/hokunet/ipc.git#02b33d697d921d887267381c63e987a6ed4f7612"
 dependencies = [
  "anyhow",
  "cid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,13 @@ members = ["cli", "provider", "sdk", "signer", "faucet"]
 resolver = "2"
 
 [workspace.package]
-authors = ["ADM Contributors"]
-description = "The Amazing Data Machine (ADM)."
+authors = ["Hoku Contributors"]
+description = "Rust interfaces & tooling for Hoku."
 edition = "2021"
-homepage = "https://github.com/amazingdatamachine/adm/"
+homepage = "https://github.com/hokunet/rust-hoku/"
 license = "MIT OR Apache-2.0"
 readme = "./README.md"
-repository = "https://github.com/amazingdatamachine/adm/"
+repository = "https://github.com/hokunet/rust-hoku/"
 keywords = ["TODO"]
 version = "0.1.0"
 
@@ -58,7 +58,7 @@ tracing = "0.1.40"
 rand = "0.8.4"
 warp = "0.3.7"
 
-# Using the same tendermint-rs dependency as tower-abci. From both we are interested in v037 modules.
+# Using the same tendermint-rs dependency as tower-abci. For both, we are interested in v037 modules.
 tendermint = { version = "0.31.1", features = ["secp256k1"] }
 tendermint-proto = "0.31.1"
 tendermint-rpc = { version = "0.31.1", features = [
@@ -70,25 +70,25 @@ tendermint-rpc = { version = "0.31.1", features = [
 fvm_shared = "4.1.0"
 fvm_ipld_encoding = "0.4.0"
 
-fendermint_actor_accumulator = { git = "ssh://git@github.com/amazingdatamachine/ipc.git" }
-fendermint_actor_machine = { git = "ssh://git@github.com/amazingdatamachine/ipc.git" }
-fendermint_actor_objectstore = { git = "ssh://git@github.com/amazingdatamachine/ipc.git" }
-fendermint_crypto = { git = "ssh://git@github.com/amazingdatamachine/ipc.git" }
-fendermint_vm_actor_interface = { git = "ssh://git@github.com/amazingdatamachine/ipc.git" }
-fendermint_vm_message = { git = "ssh://git@github.com/amazingdatamachine/ipc.git" }
+fendermint_actor_accumulator = { git = "ssh://git@github.com/hokunet/ipc.git" }
+fendermint_actor_machine = { git = "ssh://git@github.com/hokunet/ipc.git" }
+fendermint_actor_objectstore = { git = "ssh://git@github.com/hokunet/ipc.git" }
+fendermint_crypto = { git = "ssh://git@github.com/hokunet/ipc.git" }
+fendermint_vm_actor_interface = { git = "ssh://git@github.com/hokunet/ipc.git" }
+fendermint_vm_message = { git = "ssh://git@github.com/hokunet/ipc.git" }
 
-ipc_actors_abis = { git = "ssh://git@github.com/amazingdatamachine/ipc.git" }
-ipc-api = { git = "ssh://git@github.com/amazingdatamachine/ipc.git" }
+ipc_actors_abis = { git = "ssh://git@github.com/hokunet/ipc.git" }
+ipc-api = { git = "ssh://git@github.com/hokunet/ipc.git" }
 
-# Uncomment entries below when working locally on ipc and this repo simultaneously.
+# Use below when working locally on ipc and this repo simultaneously.
 # Assumes the ipc checkout is in a sibling directory with the same name.
-[patch."ssh://git@github.com/amazingdatamachine/ipc.git"]
-fendermint_actor_accumulator = { path = "../ipc/fendermint/actors/accumulator" }
-fendermint_actor_machine = { path = "../ipc/fendermint/actors/machine" }
-fendermint_actor_objectstore = { path = "../ipc/fendermint/actors/objectstore" }
-fendermint_crypto = { path = "../ipc/fendermint/crypto" }
-fendermint_vm_actor_interface = { path = "../ipc/fendermint/vm/actor_interface" }
-fendermint_vm_message = { path = "../ipc/fendermint/vm/message" }
-
-ipc_actors_abis = { path = "../ipc/contracts/binding" }
-ipc-api = { path = "../ipc/ipc/api" }
+#[patch."ssh://git@github.com/hokunet/ipc.git"]
+#fendermint_actor_accumulator = { path = "../ipc/fendermint/actors/accumulator" }
+#fendermint_actor_machine = { path = "../ipc/fendermint/actors/machine" }
+#fendermint_actor_objectstore = { path = "../ipc/fendermint/actors/objectstore" }
+#fendermint_crypto = { path = "../ipc/fendermint/crypto" }
+#fendermint_vm_actor_interface = { path = "../ipc/fendermint/vm/actor_interface" }
+#fendermint_vm_message = { path = "../ipc/fendermint/vm/message" }
+#
+#ipc_actors_abis = { path = "../ipc/contracts/binding" }
+#ipc-api = { path = "../ipc/ipc/api" }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 ADM Contributors
+Copyright (c) 2024 Hoku Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test:
 	cargo test --locked --workspace
 
 doc:
-	cargo doc --locked --no-deps --workspace --exclude adm_cli --open
+	cargo doc --locked --no-deps --workspace --exclude hoku_cli --open
 
 clean:
 	cargo clean

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# The Amazing Data Machine (ADM)
+# Rust Hoku
 
-[![License](https://img.shields.io/github/license/amazingdatamachine/adm.svg)](./LICENSE)
+[![License](https://img.shields.io/github/license/hokunet/rust-hoku.svg)](./LICENSE)
 [![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg)](https://github.com/RichardLitt/standard-readme)
 
-> ADM network interfaces & tooling for scalable subnets & onchain data storage.
+> Rust interfaces & tooling for Hoku
 
 ## Table of Contents
 
@@ -28,27 +28,27 @@
 - [License](#license)
 
 > [!CAUTION]
-> The ADM is currently an alpha testnet, and the network is subject to fortnightly changes with rolling updates.
+> Hoku is currently an alpha testnet, and the network is subject to fortnightly changes with rolling updates.
 > Please be aware that the network may be reset at any time, and **data may be deleted every two weeks**.
 > A more stable testnet will be released in the future that won't have this limitation.
 
 ## Background
 
-ADM is a decentralized data layer, enabled by subnets that are purpose built for onchain data storage.
+Hoku is a decentralized data layer, enabled by subnets that are purpose built for onchain data storage.
 It is built on top of the Filecoin Virtual Machine (FVM) and provides a horizontally scalable, verifiable, and
 cost-effective data availability layer for onchain applications, networks (e.g., DePINs), and services.
 The first _data Layer 2 (L2)_.
 A handful of specialized "machines" for object storage and data anchoring
-power the ADM's featured data services.
+power the Hoku's featured data services.
 
 ### Architecture
 
-The ADM is developed using the Filecoin [InterPlanetary Consensus (IPC) framework](https://docs.ipc.space/). IPC is a
+Hoku is developed using the Filecoin [InterPlanetary Consensus (IPC) framework](https://docs.ipc.space/). IPC is a
 blockchain scaling solution and architectural design that is an alternative to existing L2 scaling solutions and
 based on the design principles of on-demand horizontal scaling.
 
 <p align="center">
-  <img src="./img/architecture.png" alt="ADM Architecture">
+  <img src="./img/architecture.png" alt="Hoku Architecture">
 </p>
 
 #### IPC & subnets
@@ -63,12 +63,12 @@ responsible for the security of the child subnet, and the child subnet is respon
 transitions.
 
 > [!NOTE]
-> The ADM is currently a single child subnet rooted in its parent Filecoin Calibration testnet. Future versions of the
-> ADM will align more closely with IPC's permissionless subnet spawning and configurable consensus mechanisms.
+> Hoku is currently a single child subnet rooted in its parent Filecoin Calibration testnet. Future versions of
+> Hoku will align more closely with IPC's permissionless subnet spawning and configurable consensus mechanisms.
 
 #### CometBFT & state replication
 
-[CometBFT](https://docs.cometbft.com/v0.38/) (formerly known as _Tendermint_) helps the ADM achieve state machine
+[CometBFT](https://docs.cometbft.com/v0.38/) (formerly known as _Tendermint_) helps Hoku achieve state machine
 replication across all nodes in the network. Its consensus algorithm is based on a variant of Practical Byzantine Fault
 Tolerance (PBFT) and relies on a round-robin proposer selection mechanism, while incorporating elements that improve on
 PBFT's performance and communication overhead. It is a fast, battled-tested, and well-designed consensus engine.
@@ -79,7 +79,7 @@ like the Ethereum JSON RPC API.
 
 #### ABCI & Fendermint
 
-The ADM's blockchain functionality is exposed as a unified ABCI++ application controlled by CometBFT.
+Hoku's blockchain functionality is exposed as a unified ABCI++ application controlled by CometBFT.
 
 [Application Blockchain Interfaces (ABCI)](https://docs.cometbft.com/v0.38/spec/abci/) programs are an interface between
 CometBFT and the actual state machine being replicated. That is, ABCIs implement deterministic state machines to be
@@ -87,7 +87,7 @@ securely replicated by the CometBFT consensus engine. The "++" in ABCI++ refers 
 CometBFT enables compared to the original ABCI, which helps improve the overall scalability and feature surface area.
 
 Fendermint is a specialized ABCI++ interface to the Filecoin Virtual Machines (FVM) and Ethereum-compatible FEVM. It
-exposes FEVM/FVM-specific functionality within subnets, allowing the ADM subnets to behave like Filecoin but with custom
+exposes FEVM/FVM-specific functionality within subnets, allowing Hoku subnets to behave like Filecoin but with custom
 parameters to greatly improve throughput and features. Fendermint is also a standalone process that includes:
 
 - **Interpreters:** Responsible for handling commands from CometBFT.
@@ -98,14 +98,14 @@ parameters to greatly improve throughput and features. Fendermint is also a stan
 #### Consensus
 
 Checkpoints that reference subset state are pushed to the parent subnet in a bottom-up fashion, which is essential for
-the parent to validate the state transitions of the child. The ADM passes checkpointed headers to its parent and uses
-the CometBFT ledger to gather relevant signatures and data. Additionally, the ADM can contact the IPLD resolver & store
+the parent to validate the state transitions of the child. Hoku passes checkpointed headers to its parent and uses
+the CometBFT ledger to gather relevant signatures and data. Additionally, Hoku can contact the IPLD resolver & store
 to read and write data to its internal state so that it is IPLD addressable. There is also a _top-down_ sync action;
 subnets must have a view of their parent's finality, which includes the latest block hash, power table information,
 and (in the future) cross-subnetmessage passing.
 
-In general, data is represented as CIDs onchain (within an ADM machine's state), and the actual data is stored offchain
-in a node's local (networked) block store. The ADM uses the concept of a _detached payload_ asynchronous sync mechanism,
+In general, data is represented as CIDs onchain (within a Hoku machine's state), and the actual data is stored offchain
+in a node's local (networked) block store. Hoku uses the concept of a _detached payload_ asynchronous sync mechanism,
 which is a transaction that includes a CID reference to an object, but does not include the object data itself. When a
 detached payload is added to the chain, validators are required to download the object data from the network and verify
 that it matches the CID reference. This ensures that all validators have a copy of the object data and can verify the
@@ -122,10 +122,10 @@ then finally during execution of this transaction, the object is marked as `reso
 
 ### Machines (smart contracts)
 
-The ADM's core functionality is enabled with a series of data machines, which are synonymous with smart contracts or
+Hoku's core functionality is enabled with a series of data machines, which are synonymous with smart contracts or
 "actors" that run on the FVM and are used to manage, query, and update the state of the subnet. The FVM is responsible
-for executing the logic of the ADM protocol, including processing transactions, updating account balances, and managing
-the state of the network. There are three primary machines in the ADM:
+for executing the logic of Hoku protocol, including processing transactions, updating account balances, and managing
+the state of the network. There are three primary machines in Hoku:
 
 - Machine manager
 - Object store machines
@@ -164,13 +164,13 @@ CID summary in its on-chain state.
 
 ### Accounts
 
-Accounts (ECDSA, secp256k1) are used to send data-carrying transactions as you would on any blockchain system. Since the
-ADM is built on top of Filecoin's FVM, the addresses follow a _slightly_ different convention than a purely EVM-based
+Accounts (ECDSA, secp256k1) are used to send data-carrying transactions as you would on any blockchain system. Since
+Hoku is built on top of Filecoin's FVM, the addresses follow a _slightly_ different convention than a purely EVM-based
 account system. Here's a quick primer:
 
 - Addresses are prefixed with a network identifier: `t` for Filecoin testnet, or `f` for Filecoin mainnet, and there are
   five different address types denoted by the second character in the address string: `t0`/`f0` to `t4`/`f4`.
-- If you're coming from the EVM world, you'll mostly see two types in the ADM:
+- If you're coming from the EVM world, you'll mostly see two types in Hoku:
   - `t2`/`f2`: Any FVM-native contract that gets deployed, such as the object store and accumlator machines.
   - `t4`/`f4`: A namespaced contract address, and `t410`/`f410` is a specifalized namespace for Ethereum-compatible
     addresses (wallets _and_ smart contracts) on the FVM.
@@ -178,7 +178,7 @@ account system. Here's a quick primer:
   is [encoded in the FVM address string](https://docs.filecoin.io/smart-contracts/filecoin-evm-runtime/address-types#converting-to-a-0x-style-address).
 
 Once your EVM-style account is registered on a subnet, the `0x` and its corresponding `t410...`/`f410...` addresses can
-be used interchangeably on Filecoin and all ADM subnets.
+be used interchangeably on Filecoin and all Hoku subnets.
 
 ### Access control
 
@@ -202,7 +202,7 @@ Here's a quick overview of each:
 
 ## Usage
 
-The ADM comes with both a CLI and Rust SDK that expose the core network interfaces.
+Hoku comes with both a CLI and Rust SDK that expose the core network interfaces.
 You can find detailed instructions for each of these in their respective subdirectories:
 
 - CLI: [here](./cli/README.md)
@@ -210,26 +210,26 @@ You can find detailed instructions for each of these in their respective subdire
 
 ### Chain RPCs & funds
 
-Since the ADM is built on top of Filecoin, you must have FIL in your account to interact with the network. The ADM is
+Since Hoku is built on top of Filecoin, you must have FIL in your account to interact with the network. Hoku is
 currently only live on the Filecoin Calibration network, so you can get tFIL via the
 faucet [here](https://faucet.calibnet.chainsafe-fil.io/funds.html). For reference, Filecoin chain information can be
 found [here](https://chainlist.org/?search=filecoin&testnets=true).
 
 ### Limits
 
-There are a few limitations and behaviors of which to be aware when using the ADM network:
+There are a few limitations and behaviors of which to be aware when using the Hoku network:
 
 - The maximum size for a single object is 1 GiB.
 - Objects that are less than or equal to 1024 bytes are "on-chain" objects that get stored fully onchain.
 - Objects that are greater than 1024 bytes are "detached" objects that get stored offchain and resolved as a CID.
-- The current throughput of the ADM is hundreds of transactions per second (TPS) (note: this is a rough estimate and may
+- The current throughput of Hoku is hundreds of transactions per second (TPS) (note: this is a rough estimate and may
   vary based on network conditions. The node design is still under heavy development, and optimizations are being made).
 
 ## Development
 
 When developing against a local network, be sure to set the `--network` (or `NETWORK`) to `devnet`. This presumes you
-have a local-only setup running, provided by the [`ipc`](https://github.com/amazingdatamachine/ipc) repo and custom
-contracts in [`builtin-actors`](https://github.com/amazingdatamachine/builtin-actors).
+have a local-only setup running, provided by the [`ipc`](https://github.com/hokunet/ipc) repo and custom
+contracts in [`builtin-actors`](https://github.com/hokunet/builtin-actors).
 
 All the available commands include:
 
@@ -251,4 +251,4 @@ the [standard-readme](https://github.com/RichardLitt/standard-readme) specificat
 
 ## License
 
-MIT OR Apache-2.0, © 2024 ADM Contributors
+MIT OR Apache-2.0, © 2024 Hoku Contributors

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "adm_cli"
-description = "A command line interface (CLI) for the ADM."
+name = "hoku_cli"
+description = "A command line interface (CLI) for Hoku."
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
@@ -11,7 +11,7 @@ keywords.workspace = true
 version.workspace = true
 
 [[bin]]
-name = "adm"
+name = "hoku"
 path = "src/main.rs"
 
 [dependencies]
@@ -44,6 +44,6 @@ fendermint_crypto = { workspace = true }
 fendermint_vm_actor_interface = { workspace = true }
 fendermint_vm_message = { workspace = true }
 
-adm_provider = { path = "../provider" }
-adm_sdk = { path = "../sdk" }
-adm_signer = { path = "../signer" }
+hoku_provider = { path = "../provider" }
+hoku_sdk = { path = "../sdk" }
+hoku_signer = { path = "../signer" }

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,13 +1,15 @@
-# ADM CLI
+# Hoku CLI
 
-[![License](https://img.shields.io/github/license/amazingdatamachine/adm.svg)](../LICENSE)
+[![License](https://img.shields.io/github/license/hokunet/rust-hoku.svg)](../LICENSE)
 [![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg)](https://github.com/RichardLitt/standard-readme)
 
-> The Amazing Data Machine (ADM) CLI
+> Hoku CLI
 
 <!-- omit from toc -->
+
 ## Table of Contents
 
+- [Table of Contents](#table-of-contents)
 - [Background](#background)
   - [Prerequisites](#prerequisites)
 - [Usage](#usage)
@@ -44,7 +46,7 @@
 
 ## Background
 
-The ADM CLI is a tool for managing your account and data machines.
+Hoku CLI is a tool for managing your account and data machines.
 
 - _Machine manager_:
   This singleton machine is responsible for creating new object stores and/or accumulators.
@@ -62,8 +64,8 @@ Read more about data machines [here](../README.md).
 
 ### Prerequisites
 
-All data is signed onchain as transactions, so you'll need to set up an account (ECDSA, secp256k1) to use the ADM
-network. For example, any EVM-compatible wallet will work, or you can run the `adm account create` command to create a
+All data is signed onchain as transactions, so you'll need to set up an account (ECDSA, secp256k1) to use Hoku
+network. For example, any EVM-compatible wallet will work, or you can run the `hoku account create` command to create a
 private key for you.
 
 Then, make sure your account is funded with FIL, so you can pay to execute a transaction (you can use the
@@ -79,20 +81,20 @@ to use the `transfer` command. These are described in more detail below.
 To install the CLI, you'll need to download it from source, build, and install it.
 
 ```sh
-git clone https://github.com/amazingdatamachine/adm
-cd adm
+git clone https://github.com/hokunet/rust-hoku
+cd rust-hoku
 make install
 ```
 
-Once installed, you can run the `adm` command from your terminal.
+Once installed, you can run the `hoku` command from your terminal.
 
 ```sh
-adm --help
+hoku --help
 ```
 
 ### Configuration
 
-There are two flags required for the majority of the `adm` subcommands:
+There are two flags required for the majority of the `hoku` subcommands:
 
 - `--network`: Specify the chain location with RPC presets and settings that map to either `mainnet`, `testnet`,
   or `devnet`.
@@ -137,15 +139,15 @@ All the global flags can also be passed as all-caps, snake case environment vari
 
 ### Account management
 
-Interaction with the ADM network requires an account (ECDSA, secp256k1). As with any blockchain system, an account can
+Interaction with Hoku network requires an account (ECDSA, secp256k1). As with any blockchain system, an account can
 be created at will, receive / transfer funds, and send transactions. Recall that on Filecoin, and EVM `0x` prefixed
 address is equivalent to a `t410...`/`f410...` address, which is a special namespace that enables for EVM-compatiablity
 in the FVM.
 
-The `account` command allows you to execute these actions within the ADM:
+The `account` command allows you to execute these actions within Hoku:
 
 ```
-adm account
+hoku account
 ```
 
 The following subcommands are available:
@@ -161,7 +163,7 @@ The following subcommands are available:
 Create a new account from a random seed.
 
 ```
-adm account create
+hoku account create
 ```
 
 This command logs a JSON object to stdout with three properties: the private key, public key, and its corresponding
@@ -172,7 +174,7 @@ FVM-converted address.
 Create a new private key:
 
 ```
-> adm account create
+> hoku account create
 
 {
   "private_key": "d5020dd0b12d4d8d8793ff0edbaa29bd7197879ddf82d475b7e9a6a34de765b0",
@@ -184,7 +186,7 @@ Create a new private key:
 - Optionally, pipe its output into a file to store the key and metadata:
 
 ```
-> adm account create > account.json
+> hoku account create > account.json
 ```
 
 #### Get account info
@@ -192,7 +194,7 @@ Create a new private key:
 Get account information.
 
 ```
-adm account info {--private-key <PRIVATE_KEY> | --address <ADDRESS>}
+hoku account info {--private-key <PRIVATE_KEY> | --address <ADDRESS>}
 ```
 
 This commands logs a JSON object to stdout: its public key, FVM address, current sequence (nonce), current subnet
@@ -214,7 +216,7 @@ balance, and its balance on the parent subnet.
 Get account info for a specific address:
 
 ```
-> adm account info \
+> hoku account info \
 --address 0x4D5286d81317E284Cd377cB98b478552Bbe641ae
 
 {
@@ -231,15 +233,15 @@ Get account info for a specific address:
 Get an account sequence (i.e., nonce) in a subnet.
 
 ```
-adm account sequence {--private-key <PRIVATE_KEY> | --address <ADDRESS>}
+hoku account sequence {--private-key <PRIVATE_KEY> | --address <ADDRESS>}
 ```
 
 You must pass _either_ the `--private-key` or `--address` flag. An address must be in the delegated `t410` or `0x`
 format.
 
-- `adm account sequence --private-key <PRIVATE_KEY>`: Query with a private key (e.g., read from your `.env` file).
+- `hoku account sequence --private-key <PRIVATE_KEY>`: Query with a private key (e.g., read from your `.env` file).
   (e.g., read from your `.env` file).
-- `adm account sequence --address <ADDRESS>`: Query a `t410` or `0x` address.
+- `hoku account sequence --address <ADDRESS>`: Query a `t410` or `0x` address.
 
 | Flag                | Required?                | Description                                                           |
 | ------------------- | ------------------------ | --------------------------------------------------------------------- |
@@ -254,7 +256,7 @@ Get the sequence by:
 - Hex address:
 
 ```
-> adm objectstore list \
+> hoku objectstore list \
 --address 0x4D5286d81317E284Cd377cB98b478552Bbe641ae
 
 {
@@ -265,7 +267,7 @@ Get the sequence by:
 - Its equivalent `t410` address:
 
 ```
-> adm objectstore list \
+> hoku objectstore list \
 --address t410fjvjinwatc7rijtjxps4ywr4fkk56mqnolzpcnrq
 ```
 
@@ -274,14 +276,14 @@ Get the sequence by:
 Get an account balance within a specific subnet.
 
 ```
-adm account balance {--private-key <PRIVATE_KEY> | --address <ADDRESS>}
+hoku account balance {--private-key <PRIVATE_KEY> | --address <ADDRESS>}
 ```
 
 You must pass _either_ the `--private-key` or `--address` flag. An address must be in the delegated `t410` or `0x`
 format.
 
-- `adm account sequence --private-key <PRIVATE_KEY>`: Query with a private key (e.g., read from your `.env` file).
-- `adm account sequence --address <ADDRESS>`: Query a `t410` or `0x` address.
+- `hoku account sequence --private-key <PRIVATE_KEY>`: Query with a private key (e.g., read from your `.env` file).
+- `hoku account sequence --address <ADDRESS>`: Query a `t410` or `0x` address.
 
 The `--parent` flag allows you to get the balance of the parent.
 If the `--network` flag is set, it will handle all the required `--evm-...` flag presets for you,
@@ -304,7 +306,7 @@ but you _can_ override them with your own values.
 - Get the signer's balance on the subnet:
 
 ```
-> adm account balance
+> hoku account balance
 
 {
   "balance": "0.2"
@@ -314,7 +316,7 @@ but you _can_ override them with your own values.
 - Get its balance on the parent subnet:
 
 ```
-> adm account balance --parent
+> hoku account balance --parent
 
 {
   "balance": "100.5"
@@ -324,7 +326,7 @@ but you _can_ override them with your own values.
 - Get the balance at a specific address on the subnet:
 
 ```
-> adm account balance \
+> hoku account balance \
 --address 0x4D5286d81317E284Cd377cB98b478552Bbe641ae
 ```
 
@@ -333,7 +335,7 @@ but you _can_ override them with your own values.
 Deposit funds into a subnet from its parent.
 
 ```
-adm account deposit [--to <TO>] <AMOUNT>
+hoku account deposit [--to <TO>] <AMOUNT>
 ```
 
 Think of the `deposit` command as a typical transfer but _only_ from a parent to a child subnet. Both a transfer _out
@@ -363,7 +365,7 @@ values.
 - Deposit funds to the signer's address:
 
 ```
-> adm account deposit 0.1
+> hoku account deposit 0.1
 
 {
   "transactionHash": "0xcc7fdf8057dd9f024582b24fce2abe0f5e0c01f1e925fb52bd002c4456333bfc",
@@ -402,7 +404,7 @@ values.
 - Deposit funds to some other, non-signer address:
 
 ```
-> adm account deposit --to 0x181c2d11DbB674147Ba53F2cf26Cf6DF9d9cc0aC 0.1
+> hoku account deposit --to 0x181c2d11DbB674147Ba53F2cf26Cf6DF9d9cc0aC 0.1
 ```
 
 #### Withdraw funds
@@ -410,7 +412,7 @@ values.
 Withdraw funds from a subnet to its parent.
 
 ```
-adm account withdraw [--to <TO>] <AMOUNT>
+hoku account withdraw [--to <TO>] <AMOUNT>
 ```
 
 The `withdraw` command is the opposite of a `deposit`. It's somewhat like a typical transfer but _only_ from a child
@@ -439,7 +441,7 @@ will handle all the required `--evm-...` flag presets for you, but you _can_ ove
 - Withdraw funds to the signer's address:
 
 ```
-> adm account withdraw 0.1
+> hoku account withdraw 0.1
 
 {
   "transactionHash": "0xb098e39c4b358e5f55cd6f2db941092ff50b46d99db53c34101cac3f0f65f20d",
@@ -463,7 +465,7 @@ will handle all the required `--evm-...` flag presets for you, but you _can_ ove
 - Withdraw funds to some other, non-signer address:
 
 ```
-> adm account withdraw --to 0x181c2d11DbB674147Ba53F2cf26Cf6DF9d9cc0aC 0.1
+> hoku account withdraw --to 0x181c2d11DbB674147Ba53F2cf26Cf6DF9d9cc0aC 0.1
 ```
 
 #### Transfer funds
@@ -471,7 +473,7 @@ will handle all the required `--evm-...` flag presets for you, but you _can_ ove
 Transfer funds to another account in a subnet.
 
 ```
-adm account transfer --to <TO> <AMOUNT>
+hoku account transfer --to <TO> <AMOUNT>
 ```
 
 | Positionals | Description                      |
@@ -495,7 +497,7 @@ values.
 **Example:**
 
 ```
-> adm account transfer \
+> hoku account transfer \
 --to 0x4D5286d81317E284Cd377cB98b478552Bbe641ae \
 0.1
 
@@ -520,7 +522,7 @@ values.
 
 ### Machine
 
-Machines are the core building blocks of the ADM. The `machine` command allows you to retrieve machine information
+Machines are the core building blocks of Hoku. The `machine` command allows you to retrieve machine information
 relative to a specific address. This helps track which `ObjectStore` or `Accumulator` machines are tied to your account,
 which are later used in the `objectstore` and `accumulator` subcommands.
 
@@ -529,7 +531,7 @@ which are later used in the `objectstore` and `accumulator` subcommands.
 Get machine metadata at a specific address.
 
 ```
-adm machine info <ADDRESS>
+hoku machine info <ADDRESS>
 ```
 
 | Positionals | Description      |
@@ -543,7 +545,7 @@ adm machine info <ADDRESS>
 **Example:**
 
 ```
-> adm machine info t2weumc7otsi3kniwjgy2xnemws5jpi3vmbnxg4fa
+> hoku machine info t2weumc7otsi3kniwjgy2xnemws5jpi3vmbnxg4fa
 
 {
     "kind": "ObjectStore",
@@ -556,8 +558,8 @@ adm machine info <ADDRESS>
 Interact with an object store machine using either the `objectstore` or aliased `os` subcommand:
 
 ```
-adm objectstore <SUBCOMMAND>
-adm os <SUBCOMMAND>
+hoku objectstore <SUBCOMMAND>
+hoku os <SUBCOMMAND>
 ```
 
 The `objectstore` subcommand has the following subcommands:
@@ -580,7 +582,7 @@ the `query` subcommand).
 Create a new object store machine.
 
 ```
-adm objectstore create
+hoku objectstore create
 ```
 
 | Flag                | Required? | Description                                                               |
@@ -595,7 +597,7 @@ adm objectstore create
 **Example:**
 
 ```
-> adm objectstore create
+> hoku objectstore create
 
 {
   "address": "t2pefhfyobx2tdgznhcf2anr6p34z2rgso2ix7x5y",
@@ -612,14 +614,14 @@ adm objectstore create
 List object stores by owner in a subnet.
 
 ```
-adm objectstore list {--private-key <PRIVATE_KEY> | --address <ADDRESS>}
+hoku objectstore list {--private-key <PRIVATE_KEY> | --address <ADDRESS>}
 ```
 
 You must pass _either_ the `--private-key` or `--address` flag. An address must be in the delegated `t410` or `0x`
 format.
 
-- `adm objectstore list --private-key <PRIVATE_KEY>`: Query with a private key (or read from your `.env` file).
-- `adm objectstore list --address <ADDRESS>`: Query a `t410` or `0x` address.
+- `hoku objectstore list --private-key <PRIVATE_KEY>`: Query with a private key (or read from your `.env` file).
+- `hoku objectstore list --address <ADDRESS>`: Query a `t410` or `0x` address.
 
 | Flag                | Required?                | Description                                                           |
 | ------------------- | ------------------------ | --------------------------------------------------------------------- |
@@ -634,7 +636,7 @@ Query machines by:
 - A hex address:
 
 ```
-> adm objectstore list \
+> hoku objectstore list \
 --address 0x4D5286d81317E284Cd377cB98b478552Bbe641ae
 
 [
@@ -652,7 +654,7 @@ Query machines by:
 - Its equivalent `t410` address:
 
 ```
-> adm objectstore list \
+> hoku objectstore list \
 --address t410fjvjinwatc7rijtjxps4ywr4fkk56mqnolzpcnrq
 ```
 
@@ -660,7 +662,7 @@ Query machines by:
   recent `committed` height above):
 
 ```
-> adm objectstore list --height 114345
+> hoku objectstore list --height 114345
 [
   {
     "address": "t2weumc7otsi3kniwjgy2xnemws5jpi3vmbnxg4fa",
@@ -674,7 +676,7 @@ Query machines by:
 Add an object with a key prefix.
 
 ```
-adm objectstore add \
+hoku objectstore add \
 --address <ADDRESS> \
 --key <KEY> \
 [INPUT]
@@ -699,7 +701,7 @@ The `INPUT` can be a file path.
 - Push a file to the object store:
 
 ```
-> adm objectstore add \
+> hoku objectstore add \
 --address t2weumc7otsi3kniwjgy2xnemws5jpi3vmbnxg4fa \
 --key "my/object" \
 ./hello.json
@@ -718,7 +720,7 @@ The `INPUT` can be a file path.
 Get an object from the object store machine.
 
 ```
-adm objectstore get --address <ADDRESS> <KEY>
+hoku objectstore get --address <ADDRESS> <KEY>
 ```
 
 | Positionals | Description               |
@@ -739,7 +741,7 @@ Note that when you retrieve the object, it will be written to stdout.
 - Get an object and write to stdout (default behavior):
 
 ```
-> adm objectstore get \
+> hoku objectstore get \
 --address t2weumc7otsi3kniwjgy2xnemws5jpi3vmbnxg4fa \
 "my/object"
 
@@ -749,7 +751,7 @@ Note that when you retrieve the object, it will be written to stdout.
 - Download the output to a file by piping the output:
 
 ```
-> adm objectstore get \
+> hoku objectstore get \
 --address t2weumc7otsi3kniwjgy2xnemws5jpi3vmbnxg4fa \
 "my/object" > downloaded.json
 ```
@@ -757,7 +759,7 @@ Note that when you retrieve the object, it will be written to stdout.
 - Range request for a subset of bytes:
 
 ```
-> adm objectstore get \
+> hoku objectstore get \
 --address t2weumc7otsi3kniwjgy2xnemws5jpi3vmbnxg4fa \
 --range "10-14" \
 "my/object"
@@ -770,7 +772,7 @@ world
 Delete an object from the object store.
 
 ```
-adm objectstore delete \
+hoku objectstore delete \
 --address <ADDRESS> \
 <KEY>
 ```
@@ -797,7 +799,7 @@ Similar to when you `add` an object, you can specify gas settings or alter the b
 - Delete an existing object:
 
 ```
-> adm objectstore delete \
+> hoku objectstore delete \
 --address t2weumc7otsi3kniwjgy2xnemws5jpi3vmbnxg4fa \
 "my/object"
 
@@ -815,7 +817,7 @@ Similar to when you `add` an object, you can specify gas settings or alter the b
 Query across all objects in the store.
 
 ```
-adm objectstore query --address <ADDRESS>
+hoku objectstore query --address <ADDRESS>
 ```
 
 Performing a `query` lists all keys that match a given prefix _up to and including the delimiter_.
@@ -843,7 +845,7 @@ prefix `my/object/` (note: inclusive of the `/` at the end).
   prefix `my/`, but no objects are listed since the "root" is the prefix:
 
 ```
-> adm objectstore query \
+> hoku objectstore query \
 --address t2weumc7otsi3kniwjgy2xnemws5jpi3vmbnxg4fa
 
 {
@@ -859,7 +861,7 @@ prefix `my/object/` (note: inclusive of the `/` at the end).
   empty, so you know there are no more sub-objects to list:
 
 ```
-> adm objectstore query \
+> hoku objectstore query \
 --address t2weumc7otsi3kniwjgy2xnemws5jpi3vmbnxg4fa \
 --prefix "my/"
 
@@ -899,7 +901,7 @@ prefix `my/object/` (note: inclusive of the `/` at the end).
   as above.
 
 ```
-> adm objectstore query \
+> hoku objectstore query \
 --address t2weumc7otsi3kniwjgy2xnemws5jpi3vmbnxg4fa \
 --delimiter "*"
 ```
@@ -908,7 +910,7 @@ prefix `my/object/` (note: inclusive of the `/` at the end).
   _after_ `"my/object"`, so it will be the first object listed after offsetting by `1`:
 
 ```
-> adm objectstore query \
+> hoku objectstore query \
 --address t2weumc7otsi3kniwjgy2xnemws5jpi3vmbnxg4fa \
 --delimiter "/" \
 --prefix "my/" \
@@ -935,8 +937,8 @@ prefix `my/object/` (note: inclusive of the `/` at the end).
 Interact with an accumulator machine type using either the `accumulator` or aliased `ac` subcommand:
 
 ```
-adm machine accumulator <SUBCOMMAND>
-adm machine ac <SUBCOMMAND>
+hoku machine accumulator <SUBCOMMAND>
+hoku machine ac <SUBCOMMAND>
 ```
 
 The `accumulator` subcommand has the following subcommands:
@@ -954,7 +956,7 @@ The `accumulator` subcommand has the following subcommands:
 Create a new accumulator machine.
 
 ```
-adm machine accumulator create
+hoku machine accumulator create
 ```
 
 | Flag                | Required? | Description                                                               |
@@ -969,7 +971,7 @@ adm machine accumulator create
 **Example:**
 
 ```
-> adm machine accumulator create
+> hoku machine accumulator create
 
 {
   "address": "t2ous5hrcemefjn76ks2oiylz3ae2qkpkuydyu4ia",
@@ -986,14 +988,14 @@ adm machine accumulator create
 List accumulators by owner in a subnet.
 
 ```
-adm accumulator list {--private-key <PRIVATE_KEY> | --address <ADDRESS>}
+hoku accumulator list {--private-key <PRIVATE_KEY> | --address <ADDRESS>}
 ```
 
 You must pass _either_ the `--private-key` or `--address` flag. An address must be in the delegated `t410` or `0x`
 format.
 
-- `adm accumulator list --private-key <PRIVATE_KEY>`: Query with a private key (or read from your `.env` file).
-- `adm accumulator list --address <ADDRESS>`: Query a `t410` or `0x` address.
+- `hoku accumulator list --private-key <PRIVATE_KEY>`: Query with a private key (or read from your `.env` file).
+- `hoku accumulator list --address <ADDRESS>`: Query a `t410` or `0x` address.
 
 | Flag                | Required?                | Description                                                           |
 | ------------------- | ------------------------ | --------------------------------------------------------------------- |
@@ -1008,7 +1010,7 @@ Query machines by:
 - A hex address:
 
 ```
-> adm accumulator list \
+> hoku accumulator list \
 --address 0x4D5286d81317E284Cd377cB98b478552Bbe641ae
 
 [
@@ -1022,14 +1024,14 @@ Query machines by:
 - Its equivalent `t410` address:
 
 ```
-> adm accumulator list \
+> hoku accumulator list \
 --address t410fjvjinwatc7rijtjxps4ywr4fkk56mqnolzpcnrq
 ```
 
 - At a specific block height:
 
 ```
-> adm accumulator list --height 339004
+> hoku accumulator list --height 339004
 ```
 
 #### Push
@@ -1037,7 +1039,7 @@ Query machines by:
 Push a value to the accumulator.
 
 ```
-adm machine accumulator push --address <ADDRESS> [INPUT]
+hoku machine accumulator push --address <ADDRESS> [INPUT]
 ```
 
 The `INPUT` can be a file path or piped from stdin.
@@ -1057,7 +1059,7 @@ The `INPUT` can be a file path or piped from stdin.
 - Push a file to the accumulator:
 
 ```
-> adm machine accumulator push \
+> hoku machine accumulator push \
 --address t2ous5hrcemefjn76ks2oiylz3ae2qkpkuydyu4ia \
 ./hello.json
 
@@ -1076,7 +1078,7 @@ The `INPUT` can be a file path or piped from stdin.
 - Pipe from stdin:
 
 ```
-> echo '{"hello":"world"}' | adm machine accumulator push \
+> echo '{"hello":"world"}' | hoku machine accumulator push \
 --address t2ous5hrcemefjn76ks2oiylz3ae2qkpkuydyu4ia
 ```
 
@@ -1085,7 +1087,7 @@ The `INPUT` can be a file path or piped from stdin.
 Get leaf at a given index and height.
 
 ```
-adm machine accumulator leaf --address <ADDRESS> <INDEX>
+hoku machine accumulator leaf --address <ADDRESS> <INDEX>
 ```
 
 | Positionals | Description |
@@ -1102,7 +1104,7 @@ adm machine accumulator leaf --address <ADDRESS> <INDEX>
 - Get leaf at index `0` (the "hello world" object pushed above):
 
 ```
-> adm machine accumulator leaf \
+> hoku machine accumulator leaf \
 --address t2ous5hrcemefjn76ks2oiylz3ae2qkpkuydyu4ia \
 0
 
@@ -1114,7 +1116,7 @@ adm machine accumulator leaf --address <ADDRESS> <INDEX>
 Get the leaf counts at a given height.
 
 ```
-adm machine accumulator count --address <ADDRESS>
+hoku machine accumulator count --address <ADDRESS>
 ```
 
 | Flag            | Required? | Description                                                                                                  |
@@ -1127,7 +1129,7 @@ adm machine accumulator count --address <ADDRESS>
 - Get the leaf count, which is just a single leaf at this point:
 
 ```
-> adm machine accumulator root \
+> hoku machine accumulator root \
 --address t2ous5hrcemefjn76ks2oiylz3ae2qkpkuydyu4ia
 
 {
@@ -1138,10 +1140,10 @@ adm machine accumulator count --address <ADDRESS>
 - If you push another piece of data, the count will increase:
 
 ```
-> echo '{"hello":"again"}' | adm machine accumulator push \
+> echo '{"hello":"again"}' | hoku machine accumulator push \
 --address t2ous5hrcemefjn76ks2oiylz3ae2qkpkuydyu4ia
 
-> adm machine accumulator root \
+> hoku machine accumulator root \
 --address t2ous5hrcemefjn76ks2oiylz3ae2qkpkuydyu4ia
 
 {
@@ -1154,7 +1156,7 @@ adm machine accumulator count --address <ADDRESS>
 Get the peaks at a given height.
 
 ```
-adm machine accumulator peaks --address <ADDRESS>
+hoku machine accumulator peaks --address <ADDRESS>
 ```
 
 | Flag            | Required? | Description                                              |
@@ -1167,7 +1169,7 @@ adm machine accumulator peaks --address <ADDRESS>
 - Since there are only two leaves, there is only one peak since it's a balanced tree:
 
 ```
-> adm machine accumulator peaks \
+> hoku machine accumulator peaks \
 --address t2ous5hrcemefjn76ks2oiylz3ae2qkpkuydyu4ia
 
 {
@@ -1180,10 +1182,10 @@ adm machine accumulator peaks --address <ADDRESS>
 - Pushing another piece of data (i.e., three total) leads to another peak:
 
 ```
-> echo '{"hello":"basin"}' | adm machine accumulator push \
+> echo '{"hello":"basin"}' | hoku machine accumulator push \
 --address t2ous5hrcemefjn76ks2oiylz3ae2qkpkuydyu4ia
 
-> adm machine accumulator peaks \
+> hoku machine accumulator peaks \
 --address t2ous5hrcemefjn76ks2oiylz3ae2qkpkuydyu4ia
 
 {
@@ -1199,7 +1201,7 @@ adm machine accumulator peaks --address <ADDRESS>
 Get the root at a given height.
 
 ```
-adm machine accumulator root --address <ADDRESS>
+hoku machine accumulator root --address <ADDRESS>
 ```
 
 | Flag            | Required? | Description                                              |
@@ -1210,7 +1212,7 @@ adm machine accumulator root --address <ADDRESS>
 **Example:**
 
 ```
-> adm machine accumulator root \
+> hoku machine accumulator root \
 --address t2ous5hrcemefjn76ks2oiylz3ae2qkpkuydyu4ia
 
 {
@@ -1227,4 +1229,4 @@ the [standard-readme](https://github.com/RichardLitt/standard-readme) specificat
 
 ## License
 
-MIT OR Apache-2.0, © 2024 ADM Contributors
+MIT OR Apache-2.0, © 2024 Hoku Contributors

--- a/cli/src/account.rs
+++ b/cli/src/account.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::time::Duration;
@@ -11,12 +11,12 @@ use fvm_shared::{address::Address, econ::TokenAmount};
 use reqwest::{Client, Url};
 use serde_json::json;
 
-use adm_provider::{
+use hoku_provider::{
     json_rpc::JsonRpcProvider,
     util::{get_delegated_address, parse_address, parse_token_amount},
 };
-use adm_sdk::{account::Account, ipc::subnet::EVMSubnet, network::Network as SdkNetwork};
-use adm_signer::{
+use hoku_sdk::{account::Account, ipc::subnet::EVMSubnet, network::Network as SdkNetwork};
+use hoku_signer::{
     key::parse_secret_key, key::random_secretkey, AccountKind, Signer, SubnetID, Void, Wallet,
 };
 

--- a/cli/src/machine.rs
+++ b/cli/src/machine.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use clap::{Args, Subcommand};
@@ -7,11 +7,11 @@ use fendermint_vm_message::query::FvmQueryHeight;
 use fvm_shared::address::Address;
 use serde_json::json;
 
-use adm_provider::{
+use hoku_provider::{
     json_rpc::JsonRpcProvider,
     util::{get_delegated_address, parse_address, parse_query_height},
 };
-use adm_sdk::machine::info;
+use hoku_sdk::machine::info;
 
 use crate::{get_rpc_url, print_json, Cli};
 

--- a/cli/src/machine/accumulator.rs
+++ b/cli/src/machine/accumulator.rs
@@ -1,9 +1,8 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::collections::HashMap;
 
-use adm_provider::util::parse_metadata;
 use bytes::Bytes;
 use clap::{Args, Subcommand};
 use clap_stdin::FileOrStdin;
@@ -11,21 +10,22 @@ use fendermint_actor_machine::WriteAccess;
 use fendermint_crypto::SecretKey;
 use fendermint_vm_message::query::FvmQueryHeight;
 use fvm_shared::address::Address;
+use hoku_provider::util::parse_metadata;
 use serde_json::{json, Value};
 use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
 
-use adm_provider::{
+use hoku_provider::{
     json_rpc::JsonRpcProvider,
     util::{parse_address, parse_query_height},
 };
-use adm_sdk::{
+use hoku_sdk::{
     machine::{
         accumulator::{Accumulator, PushOptions},
         Machine,
     },
     TxParams,
 };
-use adm_signer::{key::parse_secret_key, AccountKind, Void, Wallet};
+use hoku_signer::{key::parse_secret_key, AccountKind, Void, Wallet};
 
 use crate::{
     get_address, get_rpc_url, get_subnet_id, print_json, AddressArgs, BroadcastMode, Cli, TxArgs,

--- a/cli/src/machine/objectstore.rs
+++ b/cli/src/machine/objectstore.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::collections::HashMap;
@@ -13,19 +13,19 @@ use serde_json::{json, Value};
 use tendermint_rpc::Url;
 use tokio::io::{self};
 
-use adm_provider::{
+use hoku_provider::{
     json_rpc::JsonRpcProvider,
     util::{parse_address, parse_metadata, parse_query_height},
 };
-use adm_sdk::machine::objectstore::{AddOptions, DeleteOptions, GetOptions};
-use adm_sdk::{
+use hoku_sdk::machine::objectstore::{AddOptions, DeleteOptions, GetOptions};
+use hoku_sdk::{
     machine::{
         objectstore::{ObjectStore, QueryOptions},
         Machine,
     },
     TxParams,
 };
-use adm_signer::{key::parse_secret_key, AccountKind, Void, Wallet};
+use hoku_signer::{key::parse_secret_key, AccountKind, Void, Wallet};
 
 use crate::{
     get_address, get_rpc_url, get_subnet_id, print_json, AddressArgs, BroadcastMode, Cli, TxArgs,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use clap::{error::ErrorKind, Args, CommandFactory, Parser, Subcommand, ValueEnum};
@@ -9,13 +9,13 @@ use serde::Serialize;
 use stderrlog::Timestamp;
 use tendermint_rpc::Url;
 
-use adm_provider::{
+use hoku_provider::{
     message::GasParams,
     tx::BroadcastMode as SDKBroadcastMode,
     util::{parse_address, parse_query_height, parse_token_amount_from_atto},
 };
-use adm_sdk::{network::Network as SdkNetwork, TxParams};
-use adm_signer::{key::parse_secret_key, AccountKind, Signer, SubnetID, Wallet};
+use hoku_sdk::{network::Network as SdkNetwork, TxParams};
+use hoku_signer::{key::parse_secret_key, AccountKind, Signer, SubnetID, Wallet};
 
 use crate::account::{handle_account, AccountArgs};
 use crate::machine::{
@@ -29,7 +29,7 @@ mod account;
 mod machine;
 
 #[derive(Clone, Debug, Parser)]
-#[command(name = "adm", author, version, about, long_about = None)]
+#[command(name = "hoku", author, version, about, long_about = None)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "adm_faucet"
+name = "hoku_faucet"
 description = "A faucet service for registering new subnet accounts and sending testnet funds."
 authors.workspace = true
 edition.workspace = true
@@ -11,7 +11,7 @@ keywords.workspace = true
 version.workspace = true
 
 [[bin]]
-name = "adm_faucet"
+name = "hoku_faucet"
 path = "src/main.rs"
 
 [dependencies]
@@ -29,6 +29,6 @@ stderrlog = { workspace = true }
 tokio = { workspace = true }
 warp = { workspace = true }
 
-adm_sdk = { path = "../sdk" }
-adm_signer = { path = "../signer" }
-adm_provider = { path = "../provider" }
+hoku_sdk = { path = "../sdk" }
+hoku_signer = { path = "../signer" }
+hoku_provider = { path = "../provider" }

--- a/faucet/src/main.rs
+++ b/faucet/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 Hoku Contributors
+// SPDX-License-Identifier: Apache-2.0, MIT
+
 use std::net::{SocketAddr, ToSocketAddrs};
 
 use anyhow::anyhow;
@@ -5,14 +8,14 @@ use clap::Parser;
 use fendermint_crypto::SecretKey;
 use stderrlog::Timestamp;
 
-use adm_signer::key::parse_secret_key;
+use hoku_signer::key::parse_secret_key;
 
 use crate::server::run;
 
 mod server;
 
 #[derive(Clone, Debug, Parser)]
-#[command(name = "adm_faucet", author, version, about, long_about = None)]
+#[command(name = "hoku_faucet", author, version, about, long_about = None)]
 struct Cli {
     /// Wallet private key (ECDSA, secp256k1) for sending faucet funds.
     #[arg(short, long, env, value_parser = parse_secret_key)]

--- a/faucet/src/server.rs
+++ b/faucet/src/server.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 Hoku Contributors
+// SPDX-License-Identifier: Apache-2.0, MIT
+
 use log::info;
 use warp::Filter;
 

--- a/faucet/src/server/register.rs
+++ b/faucet/src/server/register.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 Hoku Contributors
+// SPDX-License-Identifier: Apache-2.0, MIT
+
 use std::error::Error;
 use std::ops::Deref;
 
@@ -8,7 +11,7 @@ use serde::Deserialize;
 use serde_json::json;
 use warp::{Filter, Rejection, Reply};
 
-use adm_sdk::{account::Account, network::Network as SdkNetwork};
+use hoku_sdk::{account::Account, network::Network as SdkNetwork};
 
 use crate::server::{
     shared::{get_faucet_wallet, with_private_key, BadRequest, BaseRequest},

--- a/faucet/src/server/shared.rs
+++ b/faucet/src/server/shared.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 Hoku Contributors
+// SPDX-License-Identifier: Apache-2.0, MIT
+
 use std::convert::Infallible;
 
 use fendermint_crypto::SecretKey;
@@ -5,9 +8,9 @@ use fvm_shared::address::Address;
 use serde::{Deserialize, Deserializer, Serialize};
 use warp::{http::StatusCode, Filter, Rejection, Reply};
 
-use adm_provider::util::parse_address;
-use adm_sdk::network::Network as SdkNetwork;
-use adm_signer::{AccountKind, Wallet};
+use hoku_provider::util::parse_address;
+use hoku_sdk::network::Network as SdkNetwork;
+use hoku_signer::{AccountKind, Wallet};
 
 /// Generic base request for all routes.
 #[derive(Deserialize)]

--- a/faucet/src/server/util.rs
+++ b/faucet/src/server/util.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 Hoku Contributors
+// SPDX-License-Identifier: Apache-2.0, MIT
+
 use log::{error, info, Level};
 use serde_json::json;
 use warp::log::Info;

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "adm_provider"
-description = "A chain and object provider for the ADM."
+name = "hoku_provider"
+description = "A chain and object provider for Hoku."
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/provider/src/json_rpc.rs
+++ b/provider/src/json_rpc.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // Copyright 2022-2024 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
@@ -26,7 +26,7 @@ use crate::response::Cid;
 use crate::tx::{BroadcastMode, TxProvider, TxReceipt};
 use crate::{Provider, TendermintClient};
 
-/// A JSON RPC ADM chain provider.
+/// A JSON RPC Hoku chain provider.
 #[derive(Clone)]
 pub struct JsonRpcProvider<C = HttpClient> {
     inner: C,

--- a/provider/src/lib.rs
+++ b/provider/src/lib.rs
@@ -1,9 +1,9 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-//! # ADM Provider
+//! # Hoku Provider
 //!
-//! A chain and object provider for the ADM.
+//! A chain and object provider for Hoku.
 
 pub mod json_rpc;
 pub mod message;

--- a/provider/src/message.rs
+++ b/provider/src/message.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // Copyright 2022-2024 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/provider/src/object.rs
+++ b/provider/src/object.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use async_trait::async_trait;

--- a/provider/src/provider.rs
+++ b/provider/src/provider.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // Copyright 2022-2024 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/provider/src/query.rs
+++ b/provider/src/query.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // Copyright 2022-2024 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/provider/src/response.rs
+++ b/provider/src/response.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // Copyright 2022-2024 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/provider/src/tx.rs
+++ b/provider/src/tx.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // Copyright 2022-2024 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/provider/src/util.rs
+++ b/provider/src/util.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // Copyright 2022-2024 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "adm_sdk"
-description = "The top-level user interface for managing ADM object storage and state accumulators."
+name = "hoku_sdk"
+description = "The top-level user interface for managing Hoku object storage and state accumulators."
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
@@ -48,8 +48,8 @@ fendermint_vm_message = { workspace = true }
 ipc_actors_abis = { workspace = true }
 ipc-api = { workspace = true }
 
-adm_provider = { path = "../provider" }
-adm_signer = { path = "../signer" }
+hoku_provider = { path = "../provider" }
+hoku_signer = { path = "../signer" }
 
 iroh = { workspace = true }
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,13 +1,15 @@
-# ADM SDK
+# Hoku SDK
 
-[![License](https://img.shields.io/github/license/amazingdatamachine/adm.svg)](../LICENSE)
+[![License](https://img.shields.io/github/license/hokunet/rust-hoku.svg)](../LICENSE)
 [![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg)](https://github.com/RichardLitt/standard-readme)
 
-> The Amazing Data Machine (ADM) SDK
+> Hoku SDK
 
 <!-- omit from toc -->
+
 ## Table of Contents
 
+- [Table of Contents](#table-of-contents)
 - [Background](#background)
   - [Prerequisites](#prerequisites)
 - [Usage](#usage)
@@ -16,7 +18,7 @@
 
 ## Background
 
-The ADM SDK is a library for managing your account and data machines.
+Hoku SDK is a library for managing your account and data machines.
 
 - _Machine manager_:
   This singleton machine is responsible for creating new object stores and/or accumulators.
@@ -34,13 +36,13 @@ Read more about data machines [here](../README.md).
 
 The SDK consists of the following crates:
 
-- [`adm_provider`](../provider): A chain and object provider for the ADM.
-- [`adm_signer`](../signer): A transaction signer for the ADM.
+- [`hoku_provider`](../provider): A chain and object provider for Hoku.
+- [`hoku_signer`](../signer): A transaction signer for Hoku.
   This crate has a built-in [wallet](../signer/src/wallet.rs) signer implementation that relies on a local private key
   to sign messages.
-- [`adm_sdk`](.): The top-level user interface for managing ADM object storage and state accumulators.
+- [`hoku_sdk`](.): The top-level user interface for managing Hoku object storage and state accumulators.
 
-The `adm` crates haven't been published yet, but you can read the Cargo docs by building them locally from the repo
+The `hoku` crates haven't been published yet, but you can read the Cargo docs by building them locally from the repo
 root.
 
 ```shell
@@ -50,8 +52,7 @@ make doc
 
 ### Prerequisites
 
-All data is signed onchain as transactions, so you'll need to set up an account (ECDSA, secp256k1) to use the ADM
-network.
+All data is signed onchain as transactions, so you'll need to set up an account (ECDSA, secp256k1) to use Hoku network.
 For example, any EVM-compatible wallet will work, or you can run
 the [`account_deposit.rs`](./examples/account_deposit.rs) example to create a private key for you.
 
@@ -62,11 +63,11 @@ Follow the [examples](./examples) to get up and running.
 ## Usage
 
 Checkout the SDK [examples](./examples).
-The `adm` crates haven't been published yet, but you can use `adm_sdk` as a git dependencies.
+The `hoku` crates haven't been published yet, but you can use `hoku_sdk` as a git dependencies.
 
 ```toml
 [dependencies]
-adm_sdk = { git = "https://github.com/amazingdatamachine/adm.git" }
+hoku_sdk = { git = "https://github.com/hokunet/rust-hoku.git" }
 ```
 
 > [!NOTE]
@@ -79,7 +80,7 @@ adm_sdk = { git = "https://github.com/amazingdatamachine/adm.git" }
 > merkle-tree-rs = { git = "https://github.com/consensus-shipyard/merkle-tree-rs.git", branch = "dev" }
 > ```
 
-This issue will be fixed when the `adm` crates get published soon.
+This issue will be fixed when the `hoku` crates get published soon.
 
 ## Contributing
 
@@ -90,4 +91,4 @@ the [standard-readme](https://github.com/RichardLitt/standard-readme) specificat
 
 ## License
 
-MIT OR Apache-2.0, © 2024 ADM Contributors
+MIT OR Apache-2.0, © 2024 Hoku Contributors

--- a/sdk/examples/README.md
+++ b/sdk/examples/README.md
@@ -1,8 +1,8 @@
 # SDK Examples
 
-Explore ADM's functionalities through these practical examples.
+Explore Hoku's functionalities through these practical examples.
 
-All the examples target an `adm` testnet subnet anchored to the Filecoin Calibration network.
+All the examples target an `hoku` testnet subnet anchored to the Filecoin Calibration network.
 You can run them with `cargo run --example [example name] - [ARG]`.
 
 ## Accounts
@@ -25,7 +25,7 @@ FVM address: t410ftqeuusqto3jezobwm5lh33bnnmv2jfcoijdi44q
 
 ### Deposit funds
 
-To create transactions in the `adm` testnet, you need to first deposit some Calibration tFIL in the `adm` subnet.
+To create transactions in the `hoku` testnet, you need to first deposit some Calibration tFIL in the `hoku` subnet.
 
 1. Go to the [Calibration faucet](https://faucet.calibnet.chainsafe-fil.io/) and click "Send Funds".
 2. Enter an Ethereum address.
@@ -33,7 +33,7 @@ To create transactions in the `adm` testnet, you need to first deposit some Cali
    like the one given by running the [`account_create.rs`](account_create.rs) example.
 3. Look up the address you used on the [Calibration explorer](https://calibration.filfox.info/en).
    After about a minute, you should have 100 tFIL.
-4. Now you're ready to make a deposit to the `adm` testnet subnet.
+4. Now you're ready to make a deposit to the `hoku` testnet subnet.
 
 Run the [`account_deposit.rs`](account_deposit.rs) example using the private key for the address you used above.
 
@@ -50,7 +50,7 @@ Transaction hash: 0x03d40fc3e8d629b2b52805e4fd1fb93f2d31bb06feaa3da55408091cbde6
 
 ### Check account balance
 
-[`account_balance.rs`](account_balance.rs) shows the balance of an account in the `adm` testnet subnet.
+[`account_balance.rs`](account_balance.rs) shows the balance of an account in the `hoku` testnet subnet.
 If you ran the [`account_deposit.rs`](account_deposit.rs), this should show a non-zero balance after a few minutes.
 
 ```shell
@@ -68,7 +68,7 @@ Read the docs (run `make doc` from the repo root) for more account methods.
 ### Object storage
 
 [`objectstore_add.rs`](objectstore_add.rs) creates a new object store, adds an object, and then queries for it by key.
-To run this example, you must deposit some funds into the `adm` testnet subnet.
+To run this example, you must deposit some funds into the `hoku` testnet subnet.
 
 ```shell
 cargo run --example objectstore_add -- [YOUR_HEX_ENCODED_PRIVATE_KEY]
@@ -90,7 +90,7 @@ Read the docs (run `make doc` from the repo root) for more object store methods.
 
 [`accumulator_push.rs`](accumulator_push.rs) creates a new accumulator for state updates, pushes a new value,
 gets it back, and then qeuries for the accumulator's count and state root.
-To run this example, you must deposit some funds into the `adm` testnet subnet.
+To run this example, you must deposit some funds into the `hoku` testnet subnet.
 
 ```shell
 cargo run --example accumulator_push -- [YOUR_HEX_ENCODED_PRIVATE_KEY]

--- a/sdk/examples/account_balance.rs
+++ b/sdk/examples/account_balance.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::env;
@@ -6,8 +6,8 @@ use std::env;
 use anyhow::anyhow;
 use ethers::utils::hex::ToHexExt;
 
-use adm_sdk::{account::Account, network::Network};
-use adm_signer::{key::parse_secret_key, AccountKind, Signer, Wallet};
+use hoku_sdk::{account::Account, network::Network};
+use hoku_signer::{key::parse_secret_key, AccountKind, Signer, Wallet};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/sdk/examples/account_create.rs
+++ b/sdk/examples/account_create.rs
@@ -1,12 +1,12 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use ethers::utils::hex::ToHexExt;
 use fendermint_vm_actor_interface::eam::EthAddress;
 use fvm_shared::address::Address;
 
-use adm_sdk::network::Network;
-use adm_signer::key::random_secretkey;
+use hoku_sdk::network::Network;
+use hoku_signer::key::random_secretkey;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/sdk/examples/account_deposit.rs
+++ b/sdk/examples/account_deposit.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::env;
@@ -7,8 +7,8 @@ use anyhow::anyhow;
 use ethers::utils::hex::ToHexExt;
 use fvm_shared::econ::TokenAmount;
 
-use adm_sdk::{account::Account, network::Network};
-use adm_signer::{key::parse_secret_key, AccountKind, Signer, Wallet};
+use hoku_sdk::{account::Account, network::Network};
+use hoku_signer::{key::parse_secret_key, AccountKind, Signer, Wallet};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/sdk/examples/accumulator_push.rs
+++ b/sdk/examples/accumulator_push.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::collections::HashMap;
@@ -9,12 +9,12 @@ use bytes::Bytes;
 use fendermint_actor_machine::WriteAccess;
 use fendermint_vm_message::query::FvmQueryHeight;
 
-use adm_provider::json_rpc::JsonRpcProvider;
-use adm_sdk::{
+use hoku_provider::json_rpc::JsonRpcProvider;
+use hoku_sdk::{
     machine::{accumulator::Accumulator, Machine},
     network::Network,
 };
-use adm_signer::{key::parse_secret_key, AccountKind, Wallet};
+use hoku_signer::{key::parse_secret_key, AccountKind, Wallet};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/sdk/examples/objectstore_add.rs
+++ b/sdk/examples/objectstore_add.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::collections::HashMap;
@@ -10,13 +10,13 @@ use rand::{thread_rng, Rng};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::time::{sleep, Duration};
 
-use adm_provider::json_rpc::JsonRpcProvider;
-use adm_sdk::machine::objectstore::{AddOptions, GetOptions, QueryOptions};
-use adm_sdk::{
+use hoku_provider::json_rpc::JsonRpcProvider;
+use hoku_sdk::machine::objectstore::{AddOptions, GetOptions, QueryOptions};
+use hoku_sdk::{
     machine::{objectstore::ObjectStore, Machine},
     network::Network,
 };
-use adm_signer::{key::parse_secret_key, AccountKind, Wallet};
+use hoku_signer::{key::parse_secret_key, AccountKind, Wallet};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use anyhow::anyhow;
@@ -6,12 +6,12 @@ use ethers::prelude::TransactionReceipt;
 use fendermint_vm_message::query::FvmQueryHeight;
 use fvm_shared::{address::Address, econ::TokenAmount};
 
-use adm_provider::query::QueryProvider;
-use adm_signer::Signer;
+use hoku_provider::query::QueryProvider;
+use hoku_signer::Signer;
 
 use crate::ipc::{manager::EvmManager, subnet::EVMSubnet};
 
-/// A static wrapper around ADM account methods.
+/// A static wrapper around Hoku account methods.
 pub struct Account {}
 
 impl Account {

--- a/sdk/src/ipc.rs
+++ b/sdk/src/ipc.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 pub(crate) mod manager;

--- a/sdk/src/ipc/manager.rs
+++ b/sdk/src/ipc/manager.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // Copyright 2022-2024 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
@@ -24,7 +24,7 @@ use ipc_api::evm::{fil_to_eth_amount, payload_to_evm_address};
 use num_traits::ToPrimitive;
 use reqwest::{header::HeaderValue, Client};
 
-use adm_signer::Signer;
+use hoku_signer::Signer;
 
 use crate::ipc::subnet::EVMSubnet;
 

--- a/sdk/src/ipc/subnet.rs
+++ b/sdk/src/ipc/subnet.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::time::Duration;
@@ -6,7 +6,7 @@ use std::time::Duration;
 use fvm_shared::address::Address;
 use reqwest::Url;
 
-use adm_signer::SubnetID;
+use hoku_signer::SubnetID;
 
 /// The EVM subnet config parameters.
 #[derive(Debug, Clone)]

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1,11 +1,11 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-//! # ADM SDK
+//! # Hoku SDK
 //!
-//! The top-level user interface for managing ADM object storage and state accumulators.
+//! The top-level user interface for managing Hoku object storage and state accumulators.
 
-use adm_provider::message::GasParams;
+use hoku_provider::message::GasParams;
 
 pub mod account;
 pub mod ipc;

--- a/sdk/src/machine.rs
+++ b/sdk/src/machine.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::collections::HashMap;
@@ -17,14 +17,14 @@ use serde::Serialize;
 use tendermint::{abci::response::DeliverTx, block::Height, Hash};
 use tendermint_rpc::Client;
 
-use adm_provider::{
+use hoku_provider::{
     message::{local_message, GasParams},
     query::QueryProvider,
     response::decode_bytes,
     tx::BroadcastMode,
     Provider,
 };
-use adm_signer::Signer;
+use hoku_signer::Signer;
 
 pub mod accumulator;
 pub mod objectstore;

--- a/sdk/src/machine/accumulator.rs
+++ b/sdk/src/machine/accumulator.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::collections::HashMap;
@@ -16,14 +16,14 @@ use serde::{Deserialize, Serialize};
 use tendermint::abci::response::DeliverTx;
 use tendermint_rpc::Client;
 
-use adm_provider::{
+use hoku_provider::{
     message::{local_message, GasParams},
     query::QueryProvider,
     response::{decode_bytes, decode_cid, Cid},
     tx::{BroadcastMode, TxReceipt},
     Provider,
 };
-use adm_signer::Signer;
+use hoku_signer::Signer;
 
 use crate::machine::{deploy_machine, DeployTxReceipt, Machine};
 

--- a/sdk/src/machine/objectstore.rs
+++ b/sdk/src/machine/objectstore.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::future::Future;
@@ -34,7 +34,7 @@ use tokio::{
 };
 use tokio_stream::StreamExt;
 
-use adm_provider::{
+use hoku_provider::{
     message::{local_message, object_upload_message, GasParams},
     object::ObjectProvider,
     query::QueryProvider,
@@ -42,7 +42,7 @@ use adm_provider::{
     tx::{BroadcastMode, TxReceipt},
     Provider,
 };
-use adm_signer::Signer;
+use hoku_signer::Signer;
 
 use crate::progress::{new_message_bar, new_multi_bar, SPARKLE};
 use crate::{

--- a/sdk/src/network.rs
+++ b/sdk/src/network.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::fmt::Display;
@@ -10,8 +10,8 @@ use fvm_shared::address::{set_current_network, Address, Error, Network as FvmNet
 use serde::{Deserialize, Deserializer};
 use tendermint_rpc::Url;
 
-use adm_provider::util::parse_address;
-use adm_signer::SubnetID;
+use hoku_provider::util::parse_address;
+use hoku_signer::SubnetID;
 
 use crate::ipc::subnet::EVMSubnet;
 

--- a/sdk/src/progress.rs
+++ b/sdk/src/progress.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::fmt::Write;

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "adm_signer"
-description = "A transaction signer for the ADM."
+name = "hoku_signer"
+description = "A transaction signer for Hoku."
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
@@ -28,7 +28,7 @@ tendermint-rpc = { workspace = true }
 
 ipc-api = { workspace = true }
 
-adm_provider = { path = "../provider" }
+hoku_provider = { path = "../provider" }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -1,9 +1,9 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-//! # ADM Signer
+//! # Hoku Signer
 //!
-//! A transaction signer for the ADM.
+//! A transaction signer for Hoku.
 
 pub mod key;
 mod signer;

--- a/signer/src/signer.rs
+++ b/signer/src/signer.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use async_trait::async_trait;
@@ -10,8 +10,8 @@ use fvm_shared::{
     address::Address, crypto::signature::Signature, econ::TokenAmount, message::Message, MethodNum,
 };
 
-use adm_provider::message::GasParams;
-use adm_provider::util::get_delegated_address;
+use hoku_provider::message::GasParams;
+use hoku_provider::util::get_delegated_address;
 
 use crate::SubnetID;
 

--- a/signer/src/subnet.rs
+++ b/signer/src/subnet.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // Copyright 2022-2024 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
@@ -12,7 +12,7 @@ use fnv::FnvHasher;
 use fvm_shared::chainid::ChainID;
 use ipc_api::{error::Error, subnet_id::MAX_CHAIN_ID};
 
-use adm_provider::util::parse_address;
+use hoku_provider::util::parse_address;
 
 fn hash(bytes: &[u8]) -> u64 {
     let mut hasher = FnvHasher::default();

--- a/signer/src/void.rs
+++ b/signer/src/void.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use anyhow::anyhow;
@@ -10,7 +10,7 @@ use fvm_shared::{
     address::Address, crypto::signature::Signature, econ::TokenAmount, message::Message, MethodNum,
 };
 
-use adm_provider::message::GasParams;
+use hoku_provider::message::GasParams;
 
 use crate::signer::Signer;
 use crate::SubnetID;

--- a/signer/src/wallet.rs
+++ b/signer/src/wallet.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ADM Contributors
+// Copyright 2024 Hoku Contributors
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use anyhow::anyhow;
@@ -15,7 +15,7 @@ use fvm_shared::{
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-use adm_provider::{message::GasParams, query::QueryProvider};
+use hoku_provider::{message::GasParams, query::QueryProvider};
 
 use crate::signer::Signer;
 use crate::SubnetID;


### PR DESCRIPTION
- Search and replace adm to hoku
- We'll need to update terminology and the general presentation of Hoku to align with https://www.notion.so/Hoku-Ontology-d7744cda1a384f4bbb32fea36ba4beec#c570bb8c722b493c8656767a8dc41469

@dtbuchholz is the plan (or maybe already done?) to move the docs here to the docs site? If so, should we remove them from here?