### PR TITLE
fix: re-export foreign types

### DIFF
--- a/provider/src/json_rpc.rs
+++ b/provider/src/json_rpc.rs
@@ -17,9 +17,11 @@ use reqwest::multipart::Form;
 use tendermint::abci::response::DeliverTx;
 use tendermint::block::Height;
 use tendermint_rpc::{
-    endpoint::abci_query::AbciQuery, Client, HttpClient, Scheme, Url, WebSocketClient,
-    WebSocketClientDriver, WebSocketClientUrl,
+    endpoint::abci_query::AbciQuery, Client, Scheme, WebSocketClient, WebSocketClientDriver,
+    WebSocketClientUrl,
 };
+
+pub use tendermint_rpc::{HttpClient, Url};
 
 use crate::object::ObjectProvider;
 use crate::query::QueryProvider;

--- a/sdk/src/machine/accumulator.rs
+++ b/sdk/src/machine/accumulator.rs
@@ -9,7 +9,6 @@ use bytes::Bytes;
 use fendermint_actor_accumulator::Method::{Count, Get, Peaks, Push, Root};
 use fendermint_actor_machine::WriteAccess;
 use fendermint_vm_actor_interface::adm::Kind;
-use fendermint_vm_message::query::FvmQueryHeight;
 use fvm_ipld_encoding::{BytesSer, RawBytes};
 use fvm_shared::address::Address;
 use serde::{Deserialize, Serialize};
@@ -24,6 +23,8 @@ use hoku_provider::{
     Provider,
 };
 use hoku_signer::Signer;
+
+pub use fendermint_vm_message::query::FvmQueryHeight;
 
 use crate::machine::{deploy_machine, DeployTxReceipt, Machine};
 

--- a/signer/src/key.rs
+++ b/signer/src/key.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use anyhow::Context;
-use fendermint_crypto::SecretKey;
+pub use fendermint_crypto::SecretKey;
 
 /// Parse [`SecretKey`] from a hex string.
 pub fn parse_secret_key(hex_str: &str) -> anyhow::Result<SecretKey> {


### PR DESCRIPTION
Several types from transitive dependencies where used in public API of these crates. In order to consume these crates you needed to explicitly add those dependencies to your crate and take care to match versions exactly.

Instead this change simply re-exports these foreign types so that consumers do not need to explicitly add any dependencies.

Fixes HES-394