### PR TITLE
feat: Add chain-id command to hoku sdk and cli

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -18,7 +18,6 @@ use hoku_sdk::{network::Network as SdkNetwork, TxParams};
 use hoku_signer::{key::parse_secret_key, AccountKind, Signer, SubnetID, Wallet};
 
 use crate::account::{handle_account, AccountArgs};
-use crate::chain::{handle_chain, ChainArgs};
 use crate::credit::{handle_credit, CreditArgs};
 use crate::machine::{
     handle_machine,
@@ -27,12 +26,13 @@ use crate::machine::{
     MachineArgs,
 };
 use crate::storage::{handle_storage, StorageArgs};
+use crate::subnet::{handle_subnet, SubnetArgs};
 
 mod account;
-mod chain;
 mod credit;
 mod machine;
 mod storage;
+mod subnet;
 
 #[derive(Clone, Debug, Parser)]
 #[command(name = "hoku", author, version, about, long_about = None)]
@@ -62,8 +62,8 @@ enum Commands {
     /// Account related commands.
     #[clap(alias = "accounts")]
     Account(AccountArgs),
-    /// Chain related commands.
-    Chain(ChainArgs),
+    /// Subnet related commands.
+    Subnet(SubnetArgs),
     /// Credit related commands.
     #[clap(alias = "credits")]
     Credit(CreditArgs),
@@ -187,7 +187,7 @@ async fn main() -> anyhow::Result<()> {
 
     match &cli.command.clone() {
         Commands::Account(args) => handle_account(cli, args).await,
-        Commands::Chain(args) => handle_chain(cli, args).await,
+        Commands::Subnet(args) => handle_subnet(cli, args).await,
         Commands::Credit(args) => handle_credit(cli, args).await,
         Commands::Storage(args) => handle_storage(cli, args).await,
         Commands::Objectstore(args) => handle_objectstore(cli, args).await,

--- a/cli/src/subnet.rs
+++ b/cli/src/subnet.rs
@@ -1,28 +1,28 @@
 use crate::{get_rpc_url, print_json, Cli};
 use clap::{Args, Subcommand};
 use hoku_provider::json_rpc::JsonRpcProvider;
-use hoku_sdk::chain::Chain;
+use hoku_sdk::subnet::Subnet;
 use serde_json::json;
 
 #[derive(Clone, Debug, Args)]
-pub struct ChainArgs {
+pub struct SubnetArgs {
     #[command(subcommand)]
-    command: ChainCommands,
+    command: SubnetCommands,
 }
 
 #[derive(Clone, Debug, Subcommand)]
-enum ChainCommands {
+enum SubnetCommands {
     /// Get the ChainId.
     ChainId,
 }
 
-/// Chain commands handler.
-pub async fn handle_chain(cli: Cli, args: &ChainArgs) -> anyhow::Result<()> {
+/// Subnet commands handler.
+pub async fn handle_subnet(cli: Cli, args: &SubnetArgs) -> anyhow::Result<()> {
     let provider = JsonRpcProvider::new_http(get_rpc_url(&cli)?, None, None)?;
 
     match &args.command {
-        ChainCommands::ChainId => {
-            let chain_id = Chain::chain_id(provider).await?;
+        SubnetCommands::ChainId => {
+            let chain_id = Subnet::chain_id(provider).await?;
             print_json(&json!({"chain_id": chain_id}))
         }
     }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -8,13 +8,13 @@
 use hoku_provider::message::GasParams;
 
 pub mod account;
-pub mod chain;
 pub mod credits;
 pub mod ipc;
 pub mod machine;
 pub mod network;
 pub mod progress;
 pub mod storage;
+pub mod subnet;
 
 /// Arguments common to transactions.
 #[derive(Clone, Default, Debug)]

--- a/sdk/src/subnet.rs
+++ b/sdk/src/subnet.rs
@@ -3,10 +3,10 @@ use hoku_provider::TendermintClient;
 use tendermint::chain;
 use tendermint_rpc::Client;
 
-/// Accessors for fetching chain-wide information from a node via the CometBFT RPCs.
-pub struct Chain {}
+/// Accessors for fetching subnet-wide information from a node via the CometBFT RPCs.
+pub struct Subnet {}
 
-impl Chain {
+impl Subnet {
     pub async fn chain_id(provider: JsonRpcProvider) -> anyhow::Result<chain::Id> {
         let response = provider.underlying().status().await?;
         Ok(response.node_info.network)


### PR DESCRIPTION
example usage via the CLI:

```
> hoku subnet chain-id
{
  "chain_id": "1942764459484029"
}
```