### PR TITLE
chore: update localnet chain ID, ipc deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2290,7 +2290,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_blobs_shared"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=6f8b57ef96578af9e428052526c5452fdcfa0062#6f8b57ef96578af9e428052526c5452fdcfa0062"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=3caa3f90392c0d141a5f8d0e4bd2f260e53a478c#3caa3f90392c0d141a5f8d0e4bd2f260e53a478c"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2309,7 +2309,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_bucket"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=6f8b57ef96578af9e428052526c5452fdcfa0062#6f8b57ef96578af9e428052526c5452fdcfa0062"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=3caa3f90392c0d141a5f8d0e4bd2f260e53a478c#3caa3f90392c0d141a5f8d0e4bd2f260e53a478c"
 dependencies = [
  "anyhow",
  "cid",
@@ -2331,7 +2331,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_eam"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=6f8b57ef96578af9e428052526c5452fdcfa0062#6f8b57ef96578af9e428052526c5452fdcfa0062"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=3caa3f90392c0d141a5f8d0e4bd2f260e53a478c#3caa3f90392c0d141a5f8d0e4bd2f260e53a478c"
 dependencies = [
  "anyhow",
  "cid",
@@ -2352,7 +2352,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_machine"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=6f8b57ef96578af9e428052526c5452fdcfa0062#6f8b57ef96578af9e428052526c5452fdcfa0062"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=3caa3f90392c0d141a5f8d0e4bd2f260e53a478c#3caa3f90392c0d141a5f8d0e4bd2f260e53a478c"
 dependencies = [
  "anyhow",
  "fil_actor_adm",
@@ -2369,7 +2369,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_timehub"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=6f8b57ef96578af9e428052526c5452fdcfa0062#6f8b57ef96578af9e428052526c5452fdcfa0062"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=3caa3f90392c0d141a5f8d0e4bd2f260e53a478c#3caa3f90392c0d141a5f8d0e4bd2f260e53a478c"
 dependencies = [
  "anyhow",
  "cid",
@@ -2392,7 +2392,7 @@ dependencies = [
 [[package]]
 name = "fendermint_crypto"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=6f8b57ef96578af9e428052526c5452fdcfa0062#6f8b57ef96578af9e428052526c5452fdcfa0062"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=3caa3f90392c0d141a5f8d0e4bd2f260e53a478c#3caa3f90392c0d141a5f8d0e4bd2f260e53a478c"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2404,7 +2404,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_actor_interface"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=6f8b57ef96578af9e428052526c5452fdcfa0062#6f8b57ef96578af9e428052526c5452fdcfa0062"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=3caa3f90392c0d141a5f8d0e4bd2f260e53a478c#3caa3f90392c0d141a5f8d0e4bd2f260e53a478c"
 dependencies = [
  "anyhow",
  "cid",
@@ -2432,7 +2432,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_core"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=6f8b57ef96578af9e428052526c5452fdcfa0062#6f8b57ef96578af9e428052526c5452fdcfa0062"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=3caa3f90392c0d141a5f8d0e4bd2f260e53a478c#3caa3f90392c0d141a5f8d0e4bd2f260e53a478c"
 dependencies = [
  "cid",
  "fnv",
@@ -2446,7 +2446,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_encoding"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=6f8b57ef96578af9e428052526c5452fdcfa0062#6f8b57ef96578af9e428052526c5452fdcfa0062"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=3caa3f90392c0d141a5f8d0e4bd2f260e53a478c#3caa3f90392c0d141a5f8d0e4bd2f260e53a478c"
 dependencies = [
  "cid",
  "fvm_shared",
@@ -2459,7 +2459,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_genesis"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=6f8b57ef96578af9e428052526c5452fdcfa0062#6f8b57ef96578af9e428052526c5452fdcfa0062"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=3caa3f90392c0d141a5f8d0e4bd2f260e53a478c#3caa3f90392c0d141a5f8d0e4bd2f260e53a478c"
 dependencies = [
  "anyhow",
  "fendermint_actor_eam",
@@ -2477,7 +2477,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_message"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=6f8b57ef96578af9e428052526c5452fdcfa0062#6f8b57ef96578af9e428052526c5452fdcfa0062"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=3caa3f90392c0d141a5f8d0e4bd2f260e53a478c#3caa3f90392c0d141a5f8d0e4bd2f260e53a478c"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -2519,7 +2519,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 [[package]]
 name = "fil_actor_adm"
 version = "15.0.0-rc1"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=6f8b57ef96578af9e428052526c5452fdcfa0062#6f8b57ef96578af9e428052526c5452fdcfa0062"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=3caa3f90392c0d141a5f8d0e4bd2f260e53a478c#3caa3f90392c0d141a5f8d0e4bd2f260e53a478c"
 dependencies = [
  "anyhow",
  "cid",
@@ -2539,7 +2539,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_eam"
 version = "15.0.0-rc1"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=6f8b57ef96578af9e428052526c5452fdcfa0062#6f8b57ef96578af9e428052526c5452fdcfa0062"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=3caa3f90392c0d141a5f8d0e4bd2f260e53a478c#3caa3f90392c0d141a5f8d0e4bd2f260e53a478c"
 dependencies = [
  "anyhow",
  "cid",
@@ -2560,7 +2560,7 @@ dependencies = [
 [[package]]
 name = "fil_actors_evm_shared"
 version = "15.0.0-rc1"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=6f8b57ef96578af9e428052526c5452fdcfa0062#6f8b57ef96578af9e428052526c5452fdcfa0062"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=3caa3f90392c0d141a5f8d0e4bd2f260e53a478c#3caa3f90392c0d141a5f8d0e4bd2f260e53a478c"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding",
@@ -2573,7 +2573,7 @@ dependencies = [
 [[package]]
 name = "fil_actors_runtime"
 version = "15.0.0-rc1"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=6f8b57ef96578af9e428052526c5452fdcfa0062#6f8b57ef96578af9e428052526c5452fdcfa0062"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=3caa3f90392c0d141a5f8d0e4bd2f260e53a478c#3caa3f90392c0d141a5f8d0e4bd2f260e53a478c"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -4240,7 +4240,7 @@ dependencies = [
 [[package]]
 name = "ipc-api"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=6f8b57ef96578af9e428052526c5452fdcfa0062#6f8b57ef96578af9e428052526c5452fdcfa0062"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=3caa3f90392c0d141a5f8d0e4bd2f260e53a478c#3caa3f90392c0d141a5f8d0e4bd2f260e53a478c"
 dependencies = [
  "anyhow",
  "cid",
@@ -4255,6 +4255,7 @@ dependencies = [
  "ipc_actors_abis",
  "lazy_static",
  "log",
+ "merkle-tree-rs",
  "num-traits",
  "num_enum",
  "serde",
@@ -4268,7 +4269,7 @@ dependencies = [
 [[package]]
 name = "ipc-types"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=6f8b57ef96578af9e428052526c5452fdcfa0062#6f8b57ef96578af9e428052526c5452fdcfa0062"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=3caa3f90392c0d141a5f8d0e4bd2f260e53a478c#3caa3f90392c0d141a5f8d0e4bd2f260e53a478c"
 dependencies = [
  "anyhow",
  "cid",
@@ -4292,7 +4293,7 @@ dependencies = [
 [[package]]
 name = "ipc_actors_abis"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=6f8b57ef96578af9e428052526c5452fdcfa0062#6f8b57ef96578af9e428052526c5452fdcfa0062"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=3caa3f90392c0d141a5f8d0e4bd2f260e53a478c#3caa3f90392c0d141a5f8d0e4bd2f260e53a478c"
 dependencies = [
  "anyhow",
  "ethers",
@@ -5080,7 +5081,7 @@ dependencies = [
 [[package]]
 name = "merkle-tree-rs"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=6f8b57ef96578af9e428052526c5452fdcfa0062#6f8b57ef96578af9e428052526c5452fdcfa0062"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=3caa3f90392c0d141a5f8d0e4bd2f260e53a478c#3caa3f90392c0d141a5f8d0e4bd2f260e53a478c"
 dependencies = [
  "anyhow",
  "ethers",
@@ -9149,7 +9150,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vm_api"
 version = "1.0.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=6f8b57ef96578af9e428052526c5452fdcfa0062#6f8b57ef96578af9e428052526c5452fdcfa0062"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=3caa3f90392c0d141a5f8d0e4bd2f260e53a478c#3caa3f90392c0d141a5f8d0e4bd2f260e53a478c"
 dependencies = [
  "anyhow",
  "cid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,16 +72,16 @@ tendermint-rpc = { version = "0.31.1", features = [
 fvm_shared = "4.4.0"
 fvm_ipld_encoding = "0.4.0"
 
-fendermint_actor_blobs_shared = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "6f8b57ef96578af9e428052526c5452fdcfa0062" }
-fendermint_actor_bucket = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "6f8b57ef96578af9e428052526c5452fdcfa0062" }
-fendermint_actor_machine = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "6f8b57ef96578af9e428052526c5452fdcfa0062" }
-fendermint_actor_timehub = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "6f8b57ef96578af9e428052526c5452fdcfa0062" }
-fendermint_crypto = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "6f8b57ef96578af9e428052526c5452fdcfa0062" }
-fendermint_vm_actor_interface = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "6f8b57ef96578af9e428052526c5452fdcfa0062" }
-fendermint_vm_message = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "6f8b57ef96578af9e428052526c5452fdcfa0062" }
+fendermint_actor_blobs_shared = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "3caa3f90392c0d141a5f8d0e4bd2f260e53a478c" }
+fendermint_actor_bucket = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "3caa3f90392c0d141a5f8d0e4bd2f260e53a478c" }
+fendermint_actor_machine = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "3caa3f90392c0d141a5f8d0e4bd2f260e53a478c" }
+fendermint_actor_timehub = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "3caa3f90392c0d141a5f8d0e4bd2f260e53a478c" }
+fendermint_crypto = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "3caa3f90392c0d141a5f8d0e4bd2f260e53a478c" }
+fendermint_vm_actor_interface = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "3caa3f90392c0d141a5f8d0e4bd2f260e53a478c" }
+fendermint_vm_message = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "3caa3f90392c0d141a5f8d0e4bd2f260e53a478c" }
 
-ipc_actors_abis = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "6f8b57ef96578af9e428052526c5452fdcfa0062" }
-ipc-api = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "6f8b57ef96578af9e428052526c5452fdcfa0062" }
+ipc_actors_abis = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "3caa3f90392c0d141a5f8d0e4bd2f260e53a478c" }
+ipc-api = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "3caa3f90392c0d141a5f8d0e4bd2f260e53a478c" }
 
 # Use below when working locally on ipc and this repo simultaneously.
 # Assumes the ipc checkout is in a sibling directory with the same name.

--- a/sdk/src/network.rs
+++ b/sdk/src/network.rs
@@ -22,7 +22,7 @@ const DEVNET_EVM_GATEWAY_ADDRESS: &str = "0x77aa40b105843728088c0132e43fc4434888
 const DEVNET_EVM_REGISTRY_ADDRESS: &str = "0x74539671a1d2f1c8f200826baba665179f53a1b7";
 
 const LOCALNET_RPC_URL: &str = "http://127.0.0.1:26657";
-const LOCALNET_SUBNET_ID: &str = "/r31337/t410fkzrz3mlkyufisiuae3scumllgalzuu3wxlxa2ly"; // chain ID: 4362550583360910
+const LOCALNET_SUBNET_ID: &str = "/r31337/t410f6gbdxrbehnaeeo4mrq7wc5hgq6smnefys4qanwi"; // chain ID: 534485604105794
 const LOCALNET_EVM_RPC_URL: &str = "http://127.0.0.1:8645";
 const LOCALNET_OBJECT_API_URL: &str = "http://127.0.0.1:8001";
 const LOCALNET_EVM_GATEWAY_ADDRESS: &str = "0x77aa40b105843728088c0132e43fc44348881da8";


### PR DESCRIPTION
Updates `ipc` to account for the localnet subnet ID change: https://github.com/hokunet/ipc/commit/3caa3f90392c0d141a5f8d0e4bd2f260e53a478c