### PR TITLE
chore: bump ipc 0a90cd4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2290,7 +2290,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_blobs_shared"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=fb06e66869147892ec8b3766102a62e9450a5f09#fb06e66869147892ec8b3766102a62e9450a5f09"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=0a90cd4e22196d516ce079ba0ca1adee8e02d023#0a90cd4e22196d516ce079ba0ca1adee8e02d023"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2299,6 +2299,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_encoding",
  "fvm_shared",
+ "hoku_ipld",
  "num-derive 0.3.3",
  "num-traits",
  "serde",
@@ -2307,7 +2308,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_bucket"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=fb06e66869147892ec8b3766102a62e9450a5f09#fb06e66869147892ec8b3766102a62e9450a5f09"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=0a90cd4e22196d516ce079ba0ca1adee8e02d023#0a90cd4e22196d516ce079ba0ca1adee8e02d023"
 dependencies = [
  "anyhow",
  "cid",
@@ -2328,7 +2329,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_eam"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=fb06e66869147892ec8b3766102a62e9450a5f09#fb06e66869147892ec8b3766102a62e9450a5f09"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=0a90cd4e22196d516ce079ba0ca1adee8e02d023#0a90cd4e22196d516ce079ba0ca1adee8e02d023"
 dependencies = [
  "anyhow",
  "cid",
@@ -2349,7 +2350,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_hoku_config_shared"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=fb06e66869147892ec8b3766102a62e9450a5f09#fb06e66869147892ec8b3766102a62e9450a5f09"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=0a90cd4e22196d516ce079ba0ca1adee8e02d023#0a90cd4e22196d516ce079ba0ca1adee8e02d023"
 dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
@@ -2363,7 +2364,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_machine"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=fb06e66869147892ec8b3766102a62e9450a5f09#fb06e66869147892ec8b3766102a62e9450a5f09"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=0a90cd4e22196d516ce079ba0ca1adee8e02d023#0a90cd4e22196d516ce079ba0ca1adee8e02d023"
 dependencies = [
  "anyhow",
  "fil_actor_adm",
@@ -2379,7 +2380,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_timehub"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=fb06e66869147892ec8b3766102a62e9450a5f09#fb06e66869147892ec8b3766102a62e9450a5f09"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=0a90cd4e22196d516ce079ba0ca1adee8e02d023#0a90cd4e22196d516ce079ba0ca1adee8e02d023"
 dependencies = [
  "anyhow",
  "cid",
@@ -2400,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "fendermint_crypto"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=fb06e66869147892ec8b3766102a62e9450a5f09#fb06e66869147892ec8b3766102a62e9450a5f09"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=0a90cd4e22196d516ce079ba0ca1adee8e02d023#0a90cd4e22196d516ce079ba0ca1adee8e02d023"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2412,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_actor_interface"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=fb06e66869147892ec8b3766102a62e9450a5f09#fb06e66869147892ec8b3766102a62e9450a5f09"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=0a90cd4e22196d516ce079ba0ca1adee8e02d023#0a90cd4e22196d516ce079ba0ca1adee8e02d023"
 dependencies = [
  "anyhow",
  "cid",
@@ -2440,7 +2441,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_core"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=fb06e66869147892ec8b3766102a62e9450a5f09#fb06e66869147892ec8b3766102a62e9450a5f09"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=0a90cd4e22196d516ce079ba0ca1adee8e02d023#0a90cd4e22196d516ce079ba0ca1adee8e02d023"
 dependencies = [
  "cid",
  "fnv",
@@ -2454,7 +2455,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_encoding"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=fb06e66869147892ec8b3766102a62e9450a5f09#fb06e66869147892ec8b3766102a62e9450a5f09"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=0a90cd4e22196d516ce079ba0ca1adee8e02d023#0a90cd4e22196d516ce079ba0ca1adee8e02d023"
 dependencies = [
  "cid",
  "fvm_shared",
@@ -2467,7 +2468,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_genesis"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=fb06e66869147892ec8b3766102a62e9450a5f09#fb06e66869147892ec8b3766102a62e9450a5f09"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=0a90cd4e22196d516ce079ba0ca1adee8e02d023#0a90cd4e22196d516ce079ba0ca1adee8e02d023"
 dependencies = [
  "anyhow",
  "fendermint_actor_eam",
@@ -2485,7 +2486,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_message"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=fb06e66869147892ec8b3766102a62e9450a5f09#fb06e66869147892ec8b3766102a62e9450a5f09"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=0a90cd4e22196d516ce079ba0ca1adee8e02d023#0a90cd4e22196d516ce079ba0ca1adee8e02d023"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -2527,7 +2528,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 [[package]]
 name = "fil_actor_adm"
 version = "15.0.0-rc1"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=fb06e66869147892ec8b3766102a62e9450a5f09#fb06e66869147892ec8b3766102a62e9450a5f09"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=0a90cd4e22196d516ce079ba0ca1adee8e02d023#0a90cd4e22196d516ce079ba0ca1adee8e02d023"
 dependencies = [
  "anyhow",
  "cid",
@@ -2547,7 +2548,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_eam"
 version = "15.0.0-rc1"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=fb06e66869147892ec8b3766102a62e9450a5f09#fb06e66869147892ec8b3766102a62e9450a5f09"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=0a90cd4e22196d516ce079ba0ca1adee8e02d023#0a90cd4e22196d516ce079ba0ca1adee8e02d023"
 dependencies = [
  "anyhow",
  "cid",
@@ -2568,7 +2569,7 @@ dependencies = [
 [[package]]
 name = "fil_actors_evm_shared"
 version = "15.0.0-rc1"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=fb06e66869147892ec8b3766102a62e9450a5f09#fb06e66869147892ec8b3766102a62e9450a5f09"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=0a90cd4e22196d516ce079ba0ca1adee8e02d023#0a90cd4e22196d516ce079ba0ca1adee8e02d023"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding",
@@ -2581,7 +2582,7 @@ dependencies = [
 [[package]]
 name = "fil_actors_runtime"
 version = "15.0.0-rc1"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=fb06e66869147892ec8b3766102a62e9450a5f09#fb06e66869147892ec8b3766102a62e9450a5f09"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=0a90cd4e22196d516ce079ba0ca1adee8e02d023#0a90cd4e22196d516ce079ba0ca1adee8e02d023"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -3568,6 +3569,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hoku_ipld"
+version = "0.1.0"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=0a90cd4e22196d516ce079ba0ca1adee8e02d023#0a90cd4e22196d516ce079ba0ca1adee8e02d023"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fil_actors_runtime",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
+ "fvm_sdk",
+ "fvm_shared",
+ "integer-encoding",
+ "serde",
+]
+
+[[package]]
 name = "hoku_provider"
 version = "0.1.0"
 dependencies = [
@@ -4239,7 +4257,7 @@ dependencies = [
 [[package]]
 name = "ipc-api"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=fb06e66869147892ec8b3766102a62e9450a5f09#fb06e66869147892ec8b3766102a62e9450a5f09"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=0a90cd4e22196d516ce079ba0ca1adee8e02d023#0a90cd4e22196d516ce079ba0ca1adee8e02d023"
 dependencies = [
  "anyhow",
  "cid",
@@ -4268,7 +4286,7 @@ dependencies = [
 [[package]]
 name = "ipc-types"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=fb06e66869147892ec8b3766102a62e9450a5f09#fb06e66869147892ec8b3766102a62e9450a5f09"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=0a90cd4e22196d516ce079ba0ca1adee8e02d023#0a90cd4e22196d516ce079ba0ca1adee8e02d023"
 dependencies = [
  "anyhow",
  "cid",
@@ -4292,7 +4310,7 @@ dependencies = [
 [[package]]
 name = "ipc_actors_abis"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=fb06e66869147892ec8b3766102a62e9450a5f09#fb06e66869147892ec8b3766102a62e9450a5f09"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=0a90cd4e22196d516ce079ba0ca1adee8e02d023#0a90cd4e22196d516ce079ba0ca1adee8e02d023"
 dependencies = [
  "anyhow",
  "ethers",
@@ -5080,7 +5098,7 @@ dependencies = [
 [[package]]
 name = "merkle-tree-rs"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=fb06e66869147892ec8b3766102a62e9450a5f09#fb06e66869147892ec8b3766102a62e9450a5f09"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=0a90cd4e22196d516ce079ba0ca1adee8e02d023#0a90cd4e22196d516ce079ba0ca1adee8e02d023"
 dependencies = [
  "anyhow",
  "ethers",
@@ -9148,7 +9166,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vm_api"
 version = "1.0.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=fb06e66869147892ec8b3766102a62e9450a5f09#fb06e66869147892ec8b3766102a62e9450a5f09"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=0a90cd4e22196d516ce079ba0ca1adee8e02d023#0a90cd4e22196d516ce079ba0ca1adee8e02d023"
 dependencies = [
  "anyhow",
  "cid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,17 +70,17 @@ tendermint-rpc = { version = "0.31.1", features = [
 fvm_shared = "4.4.0"
 fvm_ipld_encoding = "0.4.0"
 
-fendermint_actor_blobs_shared = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "fb06e66869147892ec8b3766102a62e9450a5f09" }
-fendermint_actor_bucket = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "fb06e66869147892ec8b3766102a62e9450a5f09" }
-fendermint_actor_hoku_config_shared = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "fb06e66869147892ec8b3766102a62e9450a5f09" }
-fendermint_actor_machine = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "fb06e66869147892ec8b3766102a62e9450a5f09" }
-fendermint_actor_timehub = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "fb06e66869147892ec8b3766102a62e9450a5f09" }
-fendermint_crypto = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "fb06e66869147892ec8b3766102a62e9450a5f09" }
-fendermint_vm_actor_interface = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "fb06e66869147892ec8b3766102a62e9450a5f09" }
-fendermint_vm_message = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "fb06e66869147892ec8b3766102a62e9450a5f09" }
+fendermint_actor_blobs_shared = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "0a90cd4e22196d516ce079ba0ca1adee8e02d023" }
+fendermint_actor_bucket = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "0a90cd4e22196d516ce079ba0ca1adee8e02d023" }
+fendermint_actor_hoku_config_shared = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "0a90cd4e22196d516ce079ba0ca1adee8e02d023" }
+fendermint_actor_machine = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "0a90cd4e22196d516ce079ba0ca1adee8e02d023" }
+fendermint_actor_timehub = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "0a90cd4e22196d516ce079ba0ca1adee8e02d023" }
+fendermint_crypto = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "0a90cd4e22196d516ce079ba0ca1adee8e02d023" }
+fendermint_vm_actor_interface = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "0a90cd4e22196d516ce079ba0ca1adee8e02d023" }
+fendermint_vm_message = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "0a90cd4e22196d516ce079ba0ca1adee8e02d023" }
 
-ipc_actors_abis = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "fb06e66869147892ec8b3766102a62e9450a5f09" }
-ipc-api = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "fb06e66869147892ec8b3766102a62e9450a5f09" }
+ipc_actors_abis = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "0a90cd4e22196d516ce079ba0ca1adee8e02d023" }
+ipc-api = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "0a90cd4e22196d516ce079ba0ca1adee8e02d023" }
 
 # Use below when working locally on ipc and this repo simultaneously.
 # Assumes the ipc checkout is in a sibling directory with the same name.

--- a/cli/src/machine/bucket.rs
+++ b/cli/src/machine/bucket.rs
@@ -22,10 +22,7 @@ use hoku_provider::{
 };
 
 use hoku_sdk::machine::bucket::{AddOptions, DeleteOptions, GetOptions};
-use hoku_sdk::{
-    credits::{BuyOptions, Credits},
-    network::NetworkConfig,
-};
+use hoku_sdk::network::NetworkConfig;
 use hoku_sdk::{
     machine::{
         bucket::{Bucket, QueryOptions},

--- a/sdk/src/credits.rs
+++ b/sdk/src/credits.rs
@@ -187,8 +187,8 @@ pub struct CreditStats {
     pub credit_debited: String,
     /// The byte-blocks per atto token rate set at genesis.
     pub blob_credits_per_byte_block: u64,
-    /// Total number of debit accounts.
-    pub num_accounts: u64,
+    // Total number of debit accounts.
+    // pub num_accounts: u64,
 }
 
 impl From<fendermint_actor_blobs_shared::params::GetStatsReturn> for CreditStats {
@@ -199,7 +199,7 @@ impl From<fendermint_actor_blobs_shared::params::GetStatsReturn> for CreditStats
             credit_committed: v.credit_committed.to_string(),
             credit_debited: v.credit_debited.to_string(),
             blob_credits_per_byte_block: v.blob_credits_per_byte_block,
-            num_accounts: v.num_accounts,
+            // num_accounts: v.num_accounts,
         }
     }
 }

--- a/sdk/src/storage.rs
+++ b/sdk/src/storage.rs
@@ -53,8 +53,8 @@ pub struct StorageStats {
     pub capacity_free: String,
     /// The total used storage capacity of the subnet.
     pub capacity_used: String,
-    /// Total number of actively stored blobs.
-    pub num_blobs: u64,
+    // Total number of actively stored blobs.
+    // pub num_blobs: u64,
     /// Total number of currently resolving blobs.
     pub num_resolving: u64,
 }
@@ -64,7 +64,7 @@ impl From<fendermint_actor_blobs_shared::params::GetStatsReturn> for StorageStat
         Self {
             capacity_free: v.capacity_free.to_string(),
             capacity_used: v.capacity_used.to_string(),
-            num_blobs: v.num_blobs,
+            // num_blobs: v.num_blobs,
             num_resolving: v.num_resolving,
         }
     }


### PR DESCRIPTION
These changes might already be in flight elsewhere, but this makes the SDK build against latest `ipc`. 