### PR TITLE
refactor: remove public write machine arg

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -587,7 +587,6 @@ hoku bucket create
 | Flag                | Required? | Description                                                               |
 | ------------------- | --------- | ------------------------------------------------------------------------- |
 | `-p, --private-key` | Yes       | Wallet private key (ECDSA, secp256k1) for signing transactions.           |
-| `--public-write`    | No        | Allow **_public, open_** write access to the bucket.                |
 | `--gas-limit`       | No        | Gas limit for the transaction.                                            |
 | `--gas-fee-cap`     | No        | Maximum gas fee for the transaction in attoHOKU (1HOKU = 10\*\*18 attoHOKU). |
 | `--gas-premium`     | No        | Gas premium for the transaction in attoHOKU (1HOKU = 10\*\*18 attoHOKU). |
@@ -956,7 +955,6 @@ hoku timehub create
 | Flag                | Required? | Description                                                               |
 | ------------------- | --------- | ------------------------------------------------------------------------- |
 | `-p, --private-key` | Yes       | Wallet private key (ECDSA, secp256k1) for signing transactions.           |
-| `--public-write`    | No        | Allow **_public, open_** write access to the bucket.                |
 | `--gas-limit`       | No        | Gas limit for the transaction.                                            |
 | `--gas-fee-cap`     | No        | Maximum gas fee for the transaction in attoHOKU. The client will enforce a minimum value of 100 attoHOKU. 1HOKU = 10**18 attoHOKU. |
 | `--gas-premium`     | No        | Gas premium for the transaction in attoHOKU (1HOKU = 10\*\*18 attoHOKU) |

--- a/cli/src/machine/bucket.rs
+++ b/cli/src/machine/bucket.rs
@@ -65,9 +65,6 @@ struct BucketCreateArgs {
     /// The owner defaults to the signer if not specified.
     #[arg(short, long, value_parser = parse_address)]
     owner: Option<Address>,
-    /// Allow public write access to the bucket.
-    #[arg(long, default_value_t = false)]
-    public_write: bool,
     /// User-defined metadata.
     #[arg(short, long, value_parser = parse_metadata)]
     metadata: Vec<(String, String)>,

--- a/cli/src/machine/timehub.rs
+++ b/cli/src/machine/timehub.rs
@@ -63,9 +63,6 @@ struct TimehubCreateArgs {
     /// The owner defaults to the signer if not specified.
     #[arg(short, long, value_parser = parse_address)]
     owner: Option<Address>,
-    /// Allow public write access to the timehub.
-    #[arg(long, default_value_t = false)]
-    public_write: bool,
     /// User-defined metadata.
     #[arg(short, long, value_parser = parse_metadata)]
     metadata: Vec<(String, String)>,


### PR DESCRIPTION
With `WriteAccess` no longer being a feature, we can also remove this unused flag