### PR TITLE
chore: fix ssh-agent gitconfig cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,12 @@ jobs:
 
       - name: Generate documentation
         run: make doc
+
+      - name: Restore git global config
+        if: always()
+        run: |
+          MATCH=$(grep -o 'git@key-[^"]*\.github\.com:hokunet/rust-hoku' ~/.gitconfig || true)
+          if [ -n "$MATCH" ]; then
+            echo "removing key from global gitconfig"
+            git config --global --remove-section "url.${MATCH}"
+          fi


### PR DESCRIPTION
See https://github.com/webfactory/ssh-agent/issues/184.

Attempts to fix the auth errors that crop up in CI when the `webfactory/ssh-agent` action doesn't clean up the global `.gitconfig`. I'm not sure if this works yet. Will have to wait and see if a failure happens again.