### PR TITLE
fix: hide private key in help text

### DIFF
--- a/cli/src/account.rs
+++ b/cli/src/account.rs
@@ -91,7 +91,7 @@ struct InfoArgs {
 #[derive(Clone, Debug, Args)]
 struct FundArgs {
     /// Wallet private key (ECDSA, secp256k1) for signing transactions.
-    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key)]
+    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key, hide_env_values = true)]
     private_key: SecretKey,
     /// The recipient account address. If not present, the signer address is used.
     #[arg(long, value_parser = parse_address)]
@@ -106,7 +106,7 @@ struct FundArgs {
 #[derive(Clone, Debug, Args)]
 struct TransferArgs {
     /// Wallet private key (ECDSA, secp256k1) for signing transactions.
-    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key)]
+    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key, hide_env_values = true)]
     private_key: SecretKey,
     /// The recipient account address.
     #[arg(long, value_parser = parse_address)]
@@ -121,7 +121,7 @@ struct TransferArgs {
 #[derive(Clone, Debug, Args)]
 struct SetSponsorArgs {
     /// Wallet private key (ECDSA, secp256k1) for signing transactions.
-    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key)]
+    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key, hide_env_values = true)]
     private_key: SecretKey,
     /// Credit sponsor address.
     #[arg(value_parser = parse_address)]
@@ -136,7 +136,7 @@ struct SetSponsorArgs {
 #[derive(Clone, Debug, Args)]
 struct UnsetSponsorArgs {
     /// Wallet private key (ECDSA, secp256k1) for signing transactions.
-    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key)]
+    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key, hide_env_values = true)]
     private_key: SecretKey,
     /// Broadcast mode for the transaction.
     #[arg(short, long, value_enum, env = "HOKU_BROADCAST_MODE", default_value_t = BroadcastMode::Commit)]

--- a/cli/src/credit.rs
+++ b/cli/src/credit.rs
@@ -59,7 +59,7 @@ struct BalanceArgs {
 #[derive(Clone, Debug, Args)]
 struct BuyArgs {
     /// Wallet private key (ECDSA, secp256k1) for signing transactions.
-    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key)]
+    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key, hide_env_values = true)]
     private_key: SecretKey,
     /// The recipient account address. If not present, the signer address is used.
     #[arg(long, value_parser = parse_address)]
@@ -77,7 +77,7 @@ struct BuyArgs {
 #[derive(Clone, Debug, Args)]
 struct ApproveArgs {
     /// Wallet private key (ECDSA, secp256k1) for signing transactions.
-    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key)]
+    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key, hide_env_values = true)]
     private_key: SecretKey,
     /// The receiver account address.
     #[arg(long, value_parser = parse_address)]
@@ -111,7 +111,7 @@ struct ApproveArgs {
 #[derive(Clone, Debug, Args)]
 struct RevokeArgs {
     /// Wallet private key (ECDSA, secp256k1) for signing transactions.
-    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key)]
+    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key, hide_env_values = true)]
     private_key: SecretKey,
     /// The receiver account address.
     #[arg(long, value_parser = parse_address)]

--- a/cli/src/machine/bucket.rs
+++ b/cli/src/machine/bucket.rs
@@ -64,7 +64,7 @@ enum BucketCommands {
 #[derive(Clone, Debug, Args)]
 struct BucketCreateArgs {
     /// Wallet private key (ECDSA, secp256k1) for signing transactions.
-    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key)]
+    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key, hide_env_values = true)]
     private_key: SecretKey,
     /// Bucket owner address.
     /// The owner defaults to the signer if not specified.
@@ -80,7 +80,7 @@ struct BucketCreateArgs {
 #[derive(Clone, Debug, Parser)]
 struct BucketAddArgs {
     /// Wallet private key (ECDSA, secp256k1) for signing transactions.
-    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key)]
+    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key, hide_env_values = true)]
     private_key: SecretKey,
     /// Node Object API URL.
     #[arg(long, env = "HOKU_OBJECT_API_URL")]
@@ -119,7 +119,7 @@ struct BucketAddArgs {
 #[derive(Clone, Debug, Parser)]
 struct BucketDeleteArgs {
     /// Wallet private key (ECDSA, secp256k1) for signing transactions.
-    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key)]
+    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key, hide_env_values = true)]
     private_key: SecretKey,
     /// Bucket machine address.
     #[arg(short, long, value_parser = parse_address)]
@@ -200,7 +200,7 @@ struct BucketQueryArgs {
 #[derive(Clone, Debug, Args)]
 struct BucketMetadataArgs {
     /// Wallet private key (ECDSA, secp256k1) for signing transactions.
-    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key)]
+    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key, hide_env_values = true)]
     private_key: SecretKey,
     /// Bucket machine address.
     #[arg(short, long, value_parser = parse_address)]

--- a/cli/src/machine/timehub.rs
+++ b/cli/src/machine/timehub.rs
@@ -58,7 +58,7 @@ enum TimehubCommands {
 #[derive(Clone, Debug, Args)]
 struct TimehubCreateArgs {
     /// Wallet private key (ECDSA, secp256k1) for signing transactions.
-    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key)]
+    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key, hide_env_values = true)]
     private_key: SecretKey,
     /// Timehub owner address.
     /// The owner defaults to the signer if not specified.
@@ -74,7 +74,7 @@ struct TimehubCreateArgs {
 #[derive(Clone, Debug, Args)]
 struct TimehubPushArgs {
     /// Wallet private key (ECDSA, secp256k1) for signing transactions.
-    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key)]
+    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key, hide_env_values = true)]
     private_key: SecretKey,
     /// Timehub machine address.
     #[arg(short, long, value_parser = parse_address)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -164,7 +164,7 @@ impl TxArgs {
 #[derive(Clone, Debug, Args)]
 struct AddressArgs {
     /// Wallet private key (ECDSA, secp256k1) for signing transactions.
-    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key)]
+    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key, hide_env_values = true)]
     private_key: Option<SecretKey>,
     /// Account address. The signer address is used if no address is given.
     #[arg(short, long, value_parser = parse_address)]

--- a/cli/src/subnet.rs
+++ b/cli/src/subnet.rs
@@ -40,7 +40,7 @@ enum ConfigCommands {
 #[derive(Clone, Debug, Args)]
 struct SetConfigArgs {
     /// Wallet private key (ECDSA, secp256k1) for signing transactions.
-    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key)]
+    #[arg(short, long, env = "HOKU_PRIVATE_KEY", value_parser = parse_secret_key, hide_env_values = true)]
     private_key: SecretKey,
     /// The total storage capacity of the subnet.
     #[arg(long)]


### PR DESCRIPTION
Addresses #156. The private key value from the `HOKU_PRIVATE_KEY` is no longer printed in help output.

```
❯ hoku account transfer --help
Transfer funds to another account in a subnet

Usage: hoku account transfer [OPTIONS] --private-key <PRIVATE_KEY> --to <TO> <AMOUNT>

Arguments:
  <AMOUNT>  The amount to transfer in FIL

Options:
  -p, --private-key <PRIVATE_KEY>
          Wallet private key (ECDSA, secp256k1) for signing transactions [env: HOKU_PRIVATE_KEY]
      --to <TO>
          The recipient account address
      --evm-rpc-url <EVM_RPC_URL>
          The Ethereum API rpc http endpoint
      --evm-rpc-timeout <EVM_RPC_TIMEOUT>
          Timeout for calls to the Ethereum API [default: 60s]
      --evm-rpc-auth-token <EVM_RPC_AUTH_TOKEN>
          Bearer token for any Authorization header
      --evm-gateway <EVM_GATEWAY>
          The gateway contract address
      --evm-registry <EVM_REGISTRY>
          The registry contract address
      --evm-supply-source <EVM_SUPPLY_SOURCE>
          The supply source contract address
  -h, --help
          Print help
```