### PR TITLE
chore: bump ipc be6e992

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2346,7 +2346,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_blobs_shared"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3#c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=be6e99249a4c5f50d1cb3d4911530ccad0f09628#be6e99249a4c5f50d1cb3d4911530ccad0f09628"
 dependencies = [
  "anyhow",
  "data-encoding",
@@ -2363,7 +2363,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_bucket"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3#c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=be6e99249a4c5f50d1cb3d4911530ccad0f09628#be6e99249a4c5f50d1cb3d4911530ccad0f09628"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2385,7 +2385,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_eam"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3#c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=be6e99249a4c5f50d1cb3d4911530ccad0f09628#be6e99249a4c5f50d1cb3d4911530ccad0f09628"
 dependencies = [
  "anyhow",
  "cid",
@@ -2406,7 +2406,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_hoku_config_shared"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3#c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=be6e99249a4c5f50d1cb3d4911530ccad0f09628#be6e99249a4c5f50d1cb3d4911530ccad0f09628"
 dependencies = [
  "fendermint_actor_blobs_shared",
  "fil_actors_runtime",
@@ -2421,7 +2421,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_machine"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3#c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=be6e99249a4c5f50d1cb3d4911530ccad0f09628#be6e99249a4c5f50d1cb3d4911530ccad0f09628"
 dependencies = [
  "anyhow",
  "fil_actor_adm",
@@ -2437,7 +2437,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_timehub"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3#c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=be6e99249a4c5f50d1cb3d4911530ccad0f09628#be6e99249a4c5f50d1cb3d4911530ccad0f09628"
 dependencies = [
  "anyhow",
  "cid",
@@ -2458,7 +2458,7 @@ dependencies = [
 [[package]]
 name = "fendermint_crypto"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3#c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=be6e99249a4c5f50d1cb3d4911530ccad0f09628#be6e99249a4c5f50d1cb3d4911530ccad0f09628"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2470,7 +2470,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_actor_interface"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3#c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=be6e99249a4c5f50d1cb3d4911530ccad0f09628#be6e99249a4c5f50d1cb3d4911530ccad0f09628"
 dependencies = [
  "anyhow",
  "cid",
@@ -2498,7 +2498,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_core"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3#c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=be6e99249a4c5f50d1cb3d4911530ccad0f09628#be6e99249a4c5f50d1cb3d4911530ccad0f09628"
 dependencies = [
  "cid",
  "fnv",
@@ -2512,7 +2512,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_encoding"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3#c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=be6e99249a4c5f50d1cb3d4911530ccad0f09628#be6e99249a4c5f50d1cb3d4911530ccad0f09628"
 dependencies = [
  "cid",
  "fvm_shared",
@@ -2525,7 +2525,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_genesis"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3#c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=be6e99249a4c5f50d1cb3d4911530ccad0f09628#be6e99249a4c5f50d1cb3d4911530ccad0f09628"
 dependencies = [
  "anyhow",
  "fendermint_actor_eam",
@@ -2543,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_message"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3#c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=be6e99249a4c5f50d1cb3d4911530ccad0f09628#be6e99249a4c5f50d1cb3d4911530ccad0f09628"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -2585,7 +2585,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 [[package]]
 name = "fil_actor_adm"
 version = "15.0.0-rc1"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3#c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=be6e99249a4c5f50d1cb3d4911530ccad0f09628#be6e99249a4c5f50d1cb3d4911530ccad0f09628"
 dependencies = [
  "anyhow",
  "cid",
@@ -2605,7 +2605,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_eam"
 version = "15.0.0-rc1"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3#c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=be6e99249a4c5f50d1cb3d4911530ccad0f09628#be6e99249a4c5f50d1cb3d4911530ccad0f09628"
 dependencies = [
  "anyhow",
  "cid",
@@ -2626,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "fil_actors_evm_shared"
 version = "15.0.0-rc1"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3#c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=be6e99249a4c5f50d1cb3d4911530ccad0f09628#be6e99249a4c5f50d1cb3d4911530ccad0f09628"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding",
@@ -2639,7 +2639,7 @@ dependencies = [
 [[package]]
 name = "fil_actors_runtime"
 version = "15.0.0-rc1"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3#c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=be6e99249a4c5f50d1cb3d4911530ccad0f09628#be6e99249a4c5f50d1cb3d4911530ccad0f09628"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -3622,7 +3622,7 @@ dependencies = [
 [[package]]
 name = "hoku_ipld"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3#c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=be6e99249a4c5f50d1cb3d4911530ccad0f09628#be6e99249a4c5f50d1cb3d4911530ccad0f09628"
 dependencies = [
  "anyhow",
  "cid",
@@ -4300,7 +4300,7 @@ dependencies = [
 [[package]]
 name = "ipc-api"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3#c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=be6e99249a4c5f50d1cb3d4911530ccad0f09628#be6e99249a4c5f50d1cb3d4911530ccad0f09628"
 dependencies = [
  "anyhow",
  "cid",
@@ -4329,7 +4329,7 @@ dependencies = [
 [[package]]
 name = "ipc-types"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3#c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=be6e99249a4c5f50d1cb3d4911530ccad0f09628#be6e99249a4c5f50d1cb3d4911530ccad0f09628"
 dependencies = [
  "anyhow",
  "cid",
@@ -4353,7 +4353,7 @@ dependencies = [
 [[package]]
 name = "ipc_actors_abis"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3#c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=be6e99249a4c5f50d1cb3d4911530ccad0f09628#be6e99249a4c5f50d1cb3d4911530ccad0f09628"
 dependencies = [
  "anyhow",
  "ethers",
@@ -5141,7 +5141,7 @@ dependencies = [
 [[package]]
 name = "merkle-tree-rs"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3#c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=be6e99249a4c5f50d1cb3d4911530ccad0f09628#be6e99249a4c5f50d1cb3d4911530ccad0f09628"
 dependencies = [
  "anyhow",
  "ethers",
@@ -9289,7 +9289,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vm_api"
 version = "1.0.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git?rev=c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3#c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3"
+source = "git+ssh://git@github.com/hokunet/ipc.git?rev=be6e99249a4c5f50d1cb3d4911530ccad0f09628#be6e99249a4c5f50d1cb3d4911530ccad0f09628"
 dependencies = [
  "anyhow",
  "cid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,17 +70,17 @@ tendermint-rpc = { version = "0.31.1", features = [
 fvm_shared = "4.4.0"
 fvm_ipld_encoding = "0.4.0"
 
-fendermint_actor_blobs_shared = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3" }
-fendermint_actor_bucket = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3" }
-fendermint_actor_hoku_config_shared = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3" }
-fendermint_actor_machine = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3" }
-fendermint_actor_timehub = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3" }
-fendermint_crypto = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3" }
-fendermint_vm_actor_interface = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3" }
-fendermint_vm_message = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3" }
+fendermint_actor_blobs_shared = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "be6e99249a4c5f50d1cb3d4911530ccad0f09628" }
+fendermint_actor_bucket = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "be6e99249a4c5f50d1cb3d4911530ccad0f09628" }
+fendermint_actor_hoku_config_shared = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "be6e99249a4c5f50d1cb3d4911530ccad0f09628" }
+fendermint_actor_machine = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "be6e99249a4c5f50d1cb3d4911530ccad0f09628" }
+fendermint_actor_timehub = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "be6e99249a4c5f50d1cb3d4911530ccad0f09628" }
+fendermint_crypto = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "be6e99249a4c5f50d1cb3d4911530ccad0f09628" }
+fendermint_vm_actor_interface = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "be6e99249a4c5f50d1cb3d4911530ccad0f09628" }
+fendermint_vm_message = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "be6e99249a4c5f50d1cb3d4911530ccad0f09628" }
 
-ipc_actors_abis = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3" }
-ipc-api = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "c27a94fbc3984d0ef8b2cb3d69e1401b8c93c9d3" }
+ipc_actors_abis = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "be6e99249a4c5f50d1cb3d4911530ccad0f09628" }
+ipc-api = { git = "ssh://git@github.com/hokunet/ipc.git", rev = "be6e99249a4c5f50d1cb3d4911530ccad0f09628" }
 
 # Use below when working locally on ipc and this repo simultaneously.
 # Assumes the ipc checkout is in a sibling directory with the same name.


### PR DESCRIPTION
Bumps `ipc` dep to `be6e992`, which is the first commit post-flattening.