### PR TITLE
fix: handle token credit rate logging

### DIFF
--- a/cli/src/credit.rs
+++ b/cli/src/credit.rs
@@ -132,7 +132,14 @@ pub async fn handle_credit(cfg: NetworkConfig, args: &CreditArgs) -> anyhow::Res
     match &args.command {
         CreditCommands::Stats(args) => {
             let stats = Credits::stats(&provider, args.address.height).await?;
-            print_json(&json!(stats))
+            print_json(&json!({
+                "balance": stats.balance,
+                "credit_sold": stats.credit_sold,
+                "credit_committed": stats.credit_committed,
+                "credit_debited": stats.credit_debited,
+                "token_credit_rate": stats.token_credit_rate.to_string(),
+                "num_accounts": stats.num_accounts,
+            }))
         }
         CreditCommands::Buy(args) => {
             let broadcast_mode = args.broadcast_mode.get();


### PR DESCRIPTION
The current output:
```json
{
  "balance": "50006.999416020598397372",
  "credit_sold": "50007000000000000000000.0",
  "credit_committed": "446736.0",
  "credit_debited": "88248.0",
  "token_credit_rate": {
    "rate": [
      1,
      [
        0,
        3008077584,
        2076772117,
        12621774
      ]
    ]
  },
  "num_accounts": 10
}
```

The new output:
```json
{
  "balance": "50006.999416020049722563",
  "credit_sold": "50007000000000000000000.0",
  "credit_committed": "517992.0",
  "credit_debited": "95448.0",
  "token_credit_rate": "1000000000000000000000000000000000000",
  "num_accounts": 10
}
```