### PR TITLE
feat: don't display fvm addresses

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -177,8 +177,7 @@ Create a new private key:
 
 {
   "private_key": "d5020dd0b12d4d8d8793ff0edbaa29bd7197879ddf82d475b7e9a6a34de765b0",
-  "address": "0xc37ab532c1409900520a92e04a6c0482394d3133",
-  "fvm_address": "t410fyn5lkmwbicmqauqkslqeu3aeqi4u2mjturajlui"
+  "address": "0xc37ab532c1409900520a92e04a6c0482394d3133"
 }
 ```
 
@@ -220,7 +219,6 @@ Get account info for a specific address:
 
 {
   "address": "0x4d5286d81317e284cd377cb98b478552bbe641ae",
-  "fvm_address": "0x4d5286d81317e284cd377cb98b478552bbe641ae",
   "sequence": 5,
   "balance": "0.2",
   "parent_balance": "108.263573407968179933"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -178,17 +178,19 @@ struct AddressArgs {
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
+    let verbosity = cli.verbosity as usize;
+
     stderrlog::new()
         .module(module_path!())
         .quiet(cli.quiet)
-        .verbosity(cli.verbosity as usize)
+        .verbosity(verbosity)
         .timestamp(Timestamp::Millisecond)
         .init()?;
 
     let cfg = cli.network.get().get_config();
 
     match &cli.command.clone() {
-        Commands::Account(args) => handle_account(cfg, args).await,
+        Commands::Account(args) => handle_account(cfg, args, verbosity).await,
         Commands::Subnet(args) => handle_subnet(cfg, args).await,
         Commands::Storage(args) => handle_storage(cfg, args).await,
         Commands::Bucket(args) => handle_bucket(cfg, !cli.quiet, args).await,

--- a/signer/src/subnet.rs
+++ b/signer/src/subnet.rs
@@ -35,7 +35,7 @@ pub struct SubnetID {
     faux: String,
     /// A valid [`ipc_api::subnet_id::SubnetID`].
     real: ipc_api::subnet_id::SubnetID,
-    /// Explicitely set chain ID. If not set, the chain ID is computed as a hash from the subnet ID.
+    /// Explicitly set chain ID. If not set, the chain ID is computed as a hash from the subnet ID.
     explicit_chain_id: Option<ChainID>,
 }
 


### PR DESCRIPTION
# Summary

This PR removes `fvm_address` from  account info or account create commands. They are only shown when the verbose flag is used

Closes https://github.com/recallnet/rust-recall/issues/201