### PR TITLE
fix: update token credit rate type

### DIFF
--- a/provider/src/util.rs
+++ b/provider/src/util.rs
@@ -10,7 +10,7 @@ use fendermint_vm_actor_interface::eam::EthAddress;
 use fendermint_vm_message::query::FvmQueryHeight;
 use fvm_shared::{
     address::{Address, Error, Network, Payload},
-    bigint::BigInt,
+    bigint::{BigInt, BigUint},
     econ::TokenAmount,
 };
 use rust_decimal::Decimal;
@@ -70,7 +70,7 @@ pub fn parse_credit_amount(s: &str) -> anyhow::Result<Credit> {
 
 /// Parse the token to credit rate.
 pub fn parse_token_credit_rate(s: &str) -> anyhow::Result<TokenCreditRate> {
-    Ok(TokenCreditRate::from(BigInt::from_str(s)?))
+    Ok(TokenCreditRate::from(BigUint::from_str(s)?))
 }
 
 /// Parse query height from string.


### PR DESCRIPTION
There was a fix to the Token Credit Rate type in https://github.com/recallnet/ipc/pull/561/.
This PR makes the SDK and CLI compatible with those changes to `ipc`.  
Note: this change will **not** work with the testnet until after the next reset.  This means after this change is merged, we will need to ensure people using the testnet know they need to be using the `v0.1.4` tag, not the main branch.