### PR TITLE
feat: add dynamic network config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7314,6 +7314,7 @@ dependencies = [
  "serde_json",
  "stderrlog",
  "tokio",
+ "toml 0.8.20",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2239,7 +2239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5064,7 +5064,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5091,7 +5091,7 @@ checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi 0.4.0",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7173,7 +7173,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7312,6 +7312,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
+ "shellexpand",
  "stderrlog",
  "tokio",
  "toml 0.8.20",
@@ -7928,7 +7929,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8592,6 +8593,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9248,7 +9258,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10369,7 +10379,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ prost = "0.11.9"
 reqwest = { version = "0.11.27", features = ["json", "stream", "multipart"] }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.115"
+shellexpand = "3.0"
 stderrlog = "0.6.0"
 tokio = { version = "1.37.0", features = ["fs", "macros", "rt-multi-thread"] }
 tokio-util = "0.7.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ stderrlog = "0.6.0"
 tokio = { version = "1.37.0", features = ["fs", "macros", "rt-multi-thread"] }
 tokio-util = "0.7.1"
 tokio-stream = "0.1.0"
+toml = "0.8"
 tracing = "0.1.40"
 rand = "0.8.4"
 rust_decimal = "1.36"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -26,6 +26,7 @@ humantime = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
+shellexpand = { workspace = true }
 stderrlog = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,6 +28,7 @@ serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 stderrlog = { workspace = true }
 tokio = { workspace = true }
+toml = { workspace = true }
 
 recall_provider = { path = "../provider" }
 recall_sdk = { path = "../sdk" }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -240,7 +240,7 @@ fn ensure_default_network_config() -> anyhow::Result<()> {
         fs::create_dir_all(config_path.parent().expect("config file path has parent"))?;
         let default_networks = network::default_networks();
         let cfg_file_content = toml::to_string(&default_networks)?;
-        fs::write(&config_path, &cfg_file_content)?;
+        fs::write(config_path, &cfg_file_content)?;
     }
     Ok(())
 }
@@ -283,20 +283,20 @@ fn apply_flags_on_network_spec(mut spec: NetworkSpec, cli: &Cli) -> NetworkSpec 
         spec.subnet_config.evm_registry_address = x;
     }
 
-    spec.parent_config.as_mut().map(|parent| {
+    if let Some(parent) = spec.parent_config.as_mut() {
         if let Some(ref x) = cli.parent_evm_rpc_url {
             parent.evm_rpc_url = x.clone();
         }
         if let Some(ref x) = cli.parent_evm_gateway_address {
-            parent.evm_gateway_address = x.clone();
+            parent.evm_gateway_address = *x;
         }
         if let Some(ref x) = cli.parent_evm_registry_address {
-            parent.evm_registry_address = x.clone();
+            parent.evm_registry_address = *x;
         }
         if let Some(ref x) = cli.parent_evm_supply_source_address {
-            parent.evm_supply_source_address = x.clone();
+            parent.evm_supply_source_address = *x;
         }
-    });
+    }
     spec
 }
 

--- a/sdk/src/network.rs
+++ b/sdk/src/network.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 use std::time::Duration;
 use std::{collections::HashMap, fmt::Display};
 
+use anyhow::anyhow;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use recall_provider::{
@@ -172,7 +173,12 @@ impl NetworkSpec {
             FvmNetwork::Testnet
         };
         address::set_current_network(network);
-        let mut subnet_id = SubnetID::from_str(&self.subnet_config.subnet_id)?;
+        let mut subnet_id = SubnetID::from_str(&self.subnet_config.subnet_id).map_err(|err| {
+            anyhow!(
+                "invalid subnet ID '{}': {err}",
+                &self.subnet_config.subnet_id
+            )
+        })?;
         if let Some(chain_id) = self.subnet_config.chain_id {
             subnet_id = subnet_id.with_chain_id(ChainID::from(chain_id));
         }

--- a/sdk/src/network.rs
+++ b/sdk/src/network.rs
@@ -6,6 +6,8 @@ use std::time::Duration;
 use std::{collections::HashMap, fmt::Display};
 
 use anyhow::anyhow;
+use ethers::utils::hex::ToHexExt;
+use recall_provider::util::get_eth_address;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use recall_provider::{
@@ -151,7 +153,10 @@ fn serialize_address<S>(x: &Address, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    serializer.serialize_str(&x.to_string())
+    let eth_address = get_eth_address(*x)
+        .map_err(serde::ser::Error::custom)?
+        .encode_hex_with_prefix();
+    serializer.serialize_str(&eth_address)
 }
 
 fn deserialize_address<'de, D>(deserializer: D) -> Result<Address, D::Error>


### PR DESCRIPTION
This PR adds an additional CLI flag `--network-config-file` that takes a path to a TOML file that specifies a network. This flag takes precedence over `--network` flag. Here is an example of a config file that localnet deployment script generates:
```toml
rpc_url = "http://localhost:26657"
object_api_url = "http://localhost:8001"
evm_rpc_url = "http://localhost:8645"
chain_id = 248163216
subnet_id = "/r31337/t410ftq3swwuwc4p4en5blgovjturjystt2txzebfapi"
evm_gateway_address = "0x77aa40b105843728088c0132e43fc44348881da8"
evm_registry_address = "0x74539671a1d2f1c8f200826baba665179f53a1b7"

[parent_network_config]
evm_rpc_url = "http://localhost:8545"
evm_gateway_address = "0xC28746d500a86109F3c588242e708381235D6639"
evm_registry_address = "0xC36794ac0047f5978fD02106640FCE9E9eCe1A76"
evm_supply_source_address = "0x6A82CFEe9da0Fb379074EDdEC5276671cE2c9462"
```

The PR also deprecates `Localnet` `NetworkConfig`, because each network will have different config.

Close #231 