### PR TITLE
feat: also checks the file extension to guess content type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7391,6 +7391,7 @@ dependencies = [
  "ipc_actors_abis",
  "iroh",
  "lazy_static",
+ "mime_guess",
  "more-asserts",
  "num-traits",
  "peekable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ indicatif = "0.17.8"
 infer = "0.16.0"
 iroh = "0.28.1"
 lazy_static = "1.4.0"
+mime_guess = { version = "2.0.5" }
 more-asserts = "0.3.1"
 num-traits = "0.2.18"
 peekable = { version = "0.2.3", features = ["tokio"] }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -24,6 +24,7 @@ indicatif = { workspace = true }
 infer = { workspace = true }
 iroh = { workspace = true }
 lazy_static = { workspace = true }
+mime_guess = { workspace = true }
 num-traits = { workspace = true }
 peekable = { workspace = true }
 rand = { workspace = true }


### PR DESCRIPTION
We're currently only sniffing the first bytes of content to guess the content type. This PR improves that to also check for extensions. With that, a text file `hello.txt` will have a content type `text/plain` and not `application/octet-stream`.