### PR TITLE
feat: sdk tests in ci

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7401,10 +7401,12 @@ dependencies = [
  "recall_signer",
  "reqwest 0.11.27",
  "serde",
+ "shellexpand",
  "tendermint",
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "toml 0.8.20",
 ]
 
 [[package]]

--- a/dagger/ci/main.go
+++ b/dagger/ci/main.go
@@ -27,6 +27,14 @@ func (m *Ci) Test(
 
 	return m.codeContainer(source, testTargetNetwork, recallPrivateKey).
 		WithServiceBinding("localnet", m.localnetService(dockerUsername, dockerPassword)).
+		WithExec([]string{
+			"sh", "-c",
+			"make test",
+		}).
+		WithExec([]string{
+			"sh", "-c",
+			"recall --network localnet account deposit 1",
+		}).
 		Stdout(ctx)
 }
 
@@ -95,15 +103,12 @@ EOL`,
 		}).
 		WithDirectory("/src", source).
 		WithWorkdir("/src").
+		WithEnvVariable("TEST_TARGET_NETWORK_CONFIG", "/root/.config/recall/networks.toml").
 		WithEnvVariable("TEST_TARGET_NETWORK", testTargetNetwork).
 		WithSecretVariable("RECALL_PRIVATE_KEY", recallPrivateKey).
 		WithExec([]string{
 			"sh", "-c",
 			"make build install",
-		}).
-		WithExec([]string{
-			"sh", "-c",
-			"recall --network localnet account deposit 1",
 		})
 }
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -51,3 +51,5 @@ recall_signer = { path = "../signer" }
 [dev-dependencies]
 hex = { workspace = true }
 more-asserts = { workspace = true }
+shellexpand = { workspace = true }
+toml = { workspace = true }

--- a/sdk/tests/integration_test.rs
+++ b/sdk/tests/integration_test.rs
@@ -26,7 +26,7 @@ mod common;
 #[tokio::test]
 #[ignore]
 async fn runner_has_token() {
-    let network_config = common::get_network();
+    let network_config = common::get_network_config();
     let sk_env = common::get_runner_secret_key();
     let sk = parse_secret_key(&sk_env).unwrap();
     let signer = Wallet::new_secp256k1(
@@ -52,12 +52,9 @@ async fn runner_has_token() {
     assert_lt!(balance, TokenAmount::from_whole(10000));
 }
 
-// TODO: this test fails, but it seems like it's because account deplosit is broken...
 #[tokio::test]
-#[ignore]
 async fn can_deposit() {
-    let network_config = common::get_network();
-
+    let network_config = common::get_network_config();
     let sk_env = common::get_runner_secret_key();
     let sk = parse_secret_key(&sk_env).unwrap();
     let signer = Wallet::new_secp256k1(
@@ -97,7 +94,7 @@ async fn can_deposit() {
 #[tokio::test]
 #[ignore]
 async fn can_add_bucket() {
-    let network_config = common::get_network();
+    let network_config = common::get_network_config();
     let sk_env = common::get_runner_secret_key();
     let sk = parse_secret_key(&sk_env).unwrap();
     let mut signer =


### PR DESCRIPTION
Closes #244.

This PR runs the SDK tests in addition to one CLI test. I've only enabled a single SDK test that I know passes against the localnet image. We can re-enable the others and add more tests in subsequent PRs.