### PR TITLE
examples: fix index-out-of-bounds panic in `bucket_add` example

### DIFF
--- a/sdk/examples/bucket_add.rs
+++ b/sdk/examples/bucket_add.rs
@@ -26,7 +26,7 @@ async fn main() -> anyhow::Result<()> {
         return Err(anyhow!("Usage: [private key]"));
     }
 
-    let pk_kex = &args[2];
+    let pk_kex = &args[1];
     let pk = parse_secret_key(pk_kex)?;
 
     // Use testnet network defaults


### PR DESCRIPTION
#### What does this PR do?
Fixes an off-by-one error that causes the `bucket_add` example to panic before it even starts:

```sh
thread 'main' panicked at sdk/examples/bucket_add.rs:29:23:
index out of bounds: the len is 2 but the index is 2
```

THe code checks that `args.len()` is 2, because the key is in `args[1]` not `args[2]` since index 2 is out of bounds:

```rs
    if args.len() != 2 {
        return Err(anyhow!("Usage: [private key]"));
    }

    let pk_kex = &args[2];
```


The example now runs as intended:

```console
$ cargo run --example bucket_add -- <HEX_PRIVATE_KEY>
Created new bucket …
```

#### Changes
* **sdk/examples/bucket_add.rs**
  * Replace `let pk_kex = &args[2];` with `let pk_hex = &args[1];`
