### PR TITLE
feat: makefile targets for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build
         run: make build
 
-      - name: Run tests
+      - name: Lint, tests, docs
         uses: dagger/dagger-for-github@8.0.0
         with:
           version: '0.18.2'
@@ -58,9 +58,3 @@ jobs:
           module: ci
           args: test --source ../ --localnet-image "$LOCALNET_IMAGE" --docker-username "$DOCKER_USERNAME" --docker-password env://DOCKER_PASSWORD 2>&1 | grep -vi -E "resolve|containerd|libnetwork|client|daemon|checkpoint|task|^$"
           dagger-flags: '--progress plain'
-
-      - name: Run linter
-        run: make lint
-
-      - name: Generate documentation
-        run: make doc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7203,7 +7203,7 @@ dependencies = [
  "anyhow",
  "async-tempfile",
  "more-asserts",
- "rand",
+ "rand 0.8.5",
  "recall_provider",
  "recall_sdk",
  "recall_signer",

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,17 @@
-.PHONY: all build install test clean lint check-fmt check-clippy
+.PHONY: all build install test test-sdk test-cli test-all doc clean lint check-fmt check-clippy run-localnet stop-localnet
 
-all: lint build test doc
+# TODO: Use the latest localnet image once it can build with the latest IPC code
+RECALL_LOCALNET_IMAGE ?= "textile/recall-localnet:sha-dc4da8c-3e80bf0"
+
+RECALL_NETWORK_CONFIG_FILE ?= /tmp/networks.toml
+
+RECALL_NETWORK ?= localnet
+
+RECALL_PRIVATE_KEY ?= 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97
+
+RECALL_CLI ?= ./target/release/recall
+
+all: lint test-all doc
 
 build:
 	cargo build --release
@@ -9,7 +20,29 @@ install:
 	cargo install --locked --path cli
 
 test:
+	cargo test --locked --workspace --exclude recall_sdk_tests
+
+run-sdk-tests:
+	cargo test --locked -p recall_sdk_tests
+
+run-cli-tests:
+	RECALL_NETWORK=${RECALL_NETWORK} \
+	RECALL_NETWORK_CONFIG_FILE=${RECALL_NETWORK_CONFIG_FILE} \
+	RECALL_CLI=${RECALL_CLI} \
+	RECALL_PRIVATE_KEY=${RECALL_PRIVATE_KEY} \
+	./scripts/run-cli-tests.sh
+
+run-all-tests:
 	cargo test --locked --workspace
+
+test-sdk: run-localnet run-sdk-tests
+	$(MAKE) stop-localnet
+
+test-cli: build run-localnet run-cli-tests
+	$(MAKE) stop-localnet
+
+test-all: build run-localnet run-all-tests run-cli-tests
+	$(MAKE) stop-localnet
 
 doc:
 	cargo doc --locked --no-deps --workspace --exclude recall_cli --open
@@ -26,3 +59,16 @@ check-fmt:
 
 check-clippy:
 	cargo clippy --no-deps --tests -- -D clippy::all
+
+run-localnet:
+	$(MAKE) stop-localnet
+	docker run --privileged --rm -d --name recall-localnet \
+		-p 8545:8545 \
+		-p 8645:8645 \
+		-p 26657:26657  \
+		${RECALL_LOCALNET_IMAGE}
+	./scripts/check-localnet-container.sh
+	docker cp recall-localnet:/workdir/localnet-data/networks.toml ${RECALL_NETWORK_CONFIG_FILE}
+
+stop-localnet:
+	docker rm -f recall-localnet || true

--- a/README.md
+++ b/README.md
@@ -57,61 +57,43 @@ All the available commands include:
 
 - Build all crates: `make build`
 - Install the CLI: `make install`
-- Run tests: `make test`
+- Run unit tests: `make test`
 - Run linter: `make lint`
 - Run formatter: `make check-fmt`
 - Run clippy: `make check-clippy`
 - Do all of the above: `make all`
 - Clean dependencies: `make clean`
 
-## Testing
+## Integration Tests
 
-Some of the tests require a Docker container to be running for `localnet`, and so will fail if you run `make test`
-without starting the container first. You can start this container using the following command:
+The integration tests require a Docker container to be running for `localnet`. You can use the following Make commands
+to spin up a `localnet` Docker container and execute tests against it:
 
+SDK integration tests:
 ```bash
-docker run --privileged --rm --name recall-localnet \
-  -p 8545:8545 \
-  -p 8645:8645 \
-  -p 26657:26657  \
-  textile/recall-localnet:latest
+make test-sdk
+```
+
+CLI integration tests:
+```bash
+make test-cli
+```
+
+If you want to run all tests, including unit tests and SDK/CLI integration tests, you can use the following command:
+```bash
+make test-all
 ```
 
 If you'd like to test against a specific IPC commit, look for the corresponding `localnet` image in the
 [Docker Hub repository](https://hub.docker.com/r/textile/recall-localnet/tags) using the first 7 characters of the IPC
 commit hash. For example, for commit `dc4da8c14c541e1ef9e398a594e65660465c47f5`, the corresponding `localnet` image
-would be tagged `sha-dc4da8c-*` (in this case, `sha-dc4da8c-3e80bf0`). You can then run the following command:
+would be tagged `sha-dc4da8c-*` (in this case, `sha-dc4da8c-3e80bf0`).
+
+You can then specify the image tag in the Make command. For example:
 
 ```bash
-docker run --privileged --rm -d --name recall-localnet \
-  -p 8545:8545 \
-  -p 8645:8645 \
-  -p 26657:26657  \
-  textile/recall-localnet:sha-dc4da8c-3e80bf0
+RECALL_LOCALNET_IMAGE=textile/recall-localnet:sha-dc4da8c-3e80bf1 make test-sdk
 ```
-
-Note that it can take several minutes for the `localnet` container to start up and be ready for testing. You can check
-the status of the container using the following command:
-
-```text
-docker logs -f recall-localnet
-```
-
-The following logs should appear when the container is ready:
-
-```bash
-All containers started. Waiting for termination signal...
-```
-
-### Extracting Network Config
-
-To extract the network config from the `localnet` container, you can run the following command:
-
-```bash
-docker exec -it recall-localnet bash -c "cat /workdir/localnet-data/networks.toml"
-```
-
-Add the `localnet` configuration to your `~/.config/recall/networks.toml` file.
 
 ### Adding New Integration Tests
 

--- a/dagger/ci/main.go
+++ b/dagger/ci/main.go
@@ -58,14 +58,11 @@ func (m *Ci) Test(
 	}
 	return codeContainer.
 		WithServiceBinding("localnet", m.localnetService(localnetContainer)).
-		WithExec([]string{
-			"sh", "-c",
-			"make test",
-		}).
-		WithExec([]string{
-			"sh", "-c",
-			"find tests/cli -type f | sort | xargs -I{} sh -c 'chmod +x {} && {}'",
-		}).
+		WithExec([]string{"sh", "-c", "make lint"}).          // Lint
+		WithExec([]string{"sh", "-c", "make test"}).          // Unit tests
+		WithExec([]string{"sh", "-c", "make run-sdk-tests"}). // SDK integration tests
+		WithExec([]string{"sh", "-c", "make run-cli-tests"}). // CLI integration tests
+		WithExec([]string{"sh", "-c", "make doc"}).           // Docs
 		Stdout(ctx)
 }
 
@@ -148,7 +145,7 @@ func (m *Ci) codeContainer(
 		}).
 		WithDirectory("/src", source).
 		WithWorkdir("/src").
-		WithEnvVariable("TEST_TARGET_NETWORK_CONFIG", "/root/.config/recall/networks.toml").
+		WithEnvVariable("RECALL_NETWORK_CONFIG_FILE", "/root/.config/recall/networks.toml").
 		WithEnvVariable("RECALL_NETWORK", "localnet").
 		WithEnvVariable("RECALL_PRIVATE_KEY", testAccountPrivateKey).
 		WithExec([]string{

--- a/scripts/check-localnet-container.sh
+++ b/scripts/check-localnet-container.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+CONTAINER_NAME="recall-localnet"
+SEARCH_STRING="All containers started. Waiting for termination signal..."
+MAX_WAIT_TIME=300
+INTERVAL=5
+
+start_time=$(date +%s)
+
+while true; do
+    if docker logs $CONTAINER_NAME 2>&1 | grep -q "$SEARCH_STRING"; then
+        echo -e "\nLocalnet container ready!"
+        exit 0
+    fi
+
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ $elapsed_time -ge $MAX_WAIT_TIME ]; then
+        echo -e "\nLocalnet container startup failed!"
+        exit 1
+    fi
+
+    remaining=$((MAX_WAIT_TIME - elapsed_time))
+    echo -ne "Waiting for Localnet container... ${elapsed_time}s elapsed, ${remaining}s remaining\r"
+
+    sleep $INTERVAL
+done

--- a/scripts/run-cli-tests.sh
+++ b/scripts/run-cli-tests.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+: "${RECALL_NETWORK:=localnet}"
+: "${RECALL_NETWORK_CONFIG_FILE:=/tmp/networks.toml}"
+: "${RECALL_CLI:=./target/release/recall}"
+: "${RECALL_PRIVATE_KEY:=0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97}"
+
+export RECALL_NETWORK
+export RECALL_NETWORK_CONFIG_FILE
+export RECALL_CLI
+export RECALL_PRIVATE_KEY
+
+for file in $(find tests/cli -type f | sort); do
+    echo "Running test: $file"
+    chmod +x "$file"
+
+    if ! "$file"; then
+        echo "Test failed: $file"
+        exit 1
+    fi
+done
+
+echo "All tests completed successfully!"

--- a/tests/sdk/README.md
+++ b/tests/sdk/README.md
@@ -1,10 +1,14 @@
 # Integration Tests
 
-This directory contains integration tests for the sdk.  These run against the Recall network defined by the following env vars:
-  - `RECALL_PRIVATE_KEY`, a private key for a wallet that has funds on the parent chain, RECALL, and credits
+This directory contains integration tests for the sdk.
 
-An example of running these tests against localnet Anvil default account 8 follows:
-`RECALL_PRIVATE_KEY=0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97 cargo test -- --nocapture`
+You can use the following Make command to run the tests. This command will spin up a Localnet Docker container and run
+the tests against it. The `RECALL_PRIVATE_KEY` environment variable can be set to any of the private keys listed in the
+section below.
+
+```bash
+RECALL_PRIVATE_KEY=0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a make test-sdk
+```
 
 ## Anvil Test Accounts and Private Keys
 

--- a/tests/sdk/src/lib.rs
+++ b/tests/sdk/src/lib.rs
@@ -56,7 +56,7 @@ pub mod test_utils {
     ];
 
     pub fn get_network_config() -> NetworkConfig {
-        let network_config_path = env::var("TEST_TARGET_NETWORK_CONFIG")
+        let network_config_path = env::var("RECALL_NETWORK_CONFIG_FILE")
             .unwrap_or_else(|_| DEFAULT_TEST_TARGET_NETWORK_CONFIG_PATH.to_string());
         let network_config_path = shellexpand::full(network_config_path.as_str()).unwrap();
         let network_config_path = Path::new(network_config_path.as_ref());


### PR DESCRIPTION
New Makefile targets added that abstract Docker commands:

```
make test-sdk
make test-cli
make test-all
```

The existing `make test` command will revert to its original state (prior to the recent CI changes) of running unit-tests.

Closes #268.